### PR TITLE
feat(runtime): VM lifecycle on the Adapter interface (PR 10)

### DIFF
--- a/packages/runtime/adapter.go
+++ b/packages/runtime/adapter.go
@@ -34,6 +34,15 @@ type Adapter interface {
 	Exec(ctx context.Context, req ExecRequest, stdout, stderr io.Writer) (int, error)
 
 	WatchEvents(ctx context.Context, tenant Tenant) (<-chan Event, error)
+
+	// VM lifecycle. Implementations that don't support VMs return
+	// ErrNotImplemented from each method. The k8s adapter uses
+	// KubeVirt; a future docker adapter would use libvirt/qemu.
+	EnsureVM(ctx context.Context, spec VMSpec) (VMStatus, error)
+	DeleteVM(ctx context.Context, ref VMRef) error
+	ObserveVM(ctx context.Context, ref VMRef) (VMStatus, error)
+	SetVMPowerState(ctx context.Context, ref VMRef, state VMPowerState) error
+	RestartVM(ctx context.Context, ref VMRef) error
 }
 
 type Event struct {

--- a/packages/runtime/conformance/conformance.go
+++ b/packages/runtime/conformance/conformance.go
@@ -37,6 +37,7 @@ func Run(t *testing.T, factory Factory) {
 	t.Run("JobCompletes", func(t *testing.T) { testJobCompletes(t, factory) })
 	t.Run("WatchEvents", func(t *testing.T) { testWatchEvents(t, factory) })
 	t.Run("LogsRequiresWorkload", func(t *testing.T) { testLogsRequiresWorkload(t, factory) })
+	t.Run("VMLifecycle", func(t *testing.T) { testVMLifecycle(t, factory) })
 }
 
 func testTenantLifecycle(t *testing.T, factory Factory) {
@@ -242,6 +243,54 @@ func testLogsRequiresWorkload(t *testing.T, factory Factory) {
 	err := a.Logs(ctx, rt.LogOptions{Ref: rt.WorkloadRef{Tenant: "alpha", Name: "ghost"}}, &buf)
 	if !errors.Is(err, rt.ErrNotFound) && !errors.Is(err, rt.ErrNotImplemented) {
 		t.Fatalf("Logs(missing) = %v, want ErrNotFound or ErrNotImplemented", err)
+	}
+}
+
+// testVMLifecycle exercises EnsureVM / SetVMPowerState / RestartVM /
+// ObserveVM / DeleteVM. Adapters that don't support VMs (docker stub)
+// signal that by returning ErrNotImplemented from EnsureVM; the suite
+// then skips the rest of the subtests for that adapter.
+func testVMLifecycle(t *testing.T, factory Factory) {
+	a, done := factory(t)
+	defer done()
+	ctx := context.Background()
+
+	if err := a.EnsureTenant(ctx, "alpha"); err != nil {
+		t.Fatalf("EnsureTenant: %v", err)
+	}
+	ref := rt.VMRef{Tenant: "alpha", Name: "win11"}
+	spec := rt.VMSpec{Ref: ref, Spec: map[string]any{"running": true}}
+
+	status, err := a.EnsureVM(ctx, spec)
+	if errors.Is(err, rt.ErrNotImplemented) {
+		t.Skipf("adapter does not implement VM lifecycle: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("EnsureVM: %v", err)
+	}
+	if status.Ref != ref {
+		t.Fatalf("status.Ref = %v, want %v", status.Ref, ref)
+	}
+
+	if err := a.SetVMPowerState(ctx, ref, rt.VMStopped); err != nil {
+		t.Fatalf("SetVMPowerState(Stopped): %v", err)
+	}
+	if err := a.RestartVM(ctx, ref); err != nil {
+		t.Fatalf("RestartVM: %v", err)
+	}
+
+	if _, err := a.ObserveVM(ctx, ref); err != nil {
+		t.Fatalf("ObserveVM: %v", err)
+	}
+
+	if err := a.DeleteVM(ctx, ref); err != nil {
+		t.Fatalf("DeleteVM: %v", err)
+	}
+	if err := a.DeleteVM(ctx, ref); err != nil {
+		t.Fatalf("DeleteVM idempotent: %v", err)
+	}
+	if _, err := a.ObserveVM(ctx, ref); !errors.Is(err, rt.ErrNotFound) {
+		t.Fatalf("ObserveVM after delete = %v, want ErrNotFound", err)
 	}
 }
 

--- a/packages/runtime/docker/adapter.go
+++ b/packages/runtime/docker/adapter.go
@@ -52,3 +52,19 @@ func (a *Adapter) Exec(_ context.Context, _ rt.ExecRequest, _, _ io.Writer) (int
 func (a *Adapter) WatchEvents(_ context.Context, _ rt.Tenant) (<-chan rt.Event, error) {
 	return nil, rt.ErrNotImplemented
 }
+
+func (a *Adapter) EnsureVM(_ context.Context, _ rt.VMSpec) (rt.VMStatus, error) {
+	return rt.VMStatus{}, rt.ErrNotImplemented
+}
+
+func (a *Adapter) DeleteVM(_ context.Context, _ rt.VMRef) error { return rt.ErrNotImplemented }
+
+func (a *Adapter) ObserveVM(_ context.Context, _ rt.VMRef) (rt.VMStatus, error) {
+	return rt.VMStatus{}, rt.ErrNotImplemented
+}
+
+func (a *Adapter) SetVMPowerState(_ context.Context, _ rt.VMRef, _ rt.VMPowerState) error {
+	return rt.ErrNotImplemented
+}
+
+func (a *Adapter) RestartVM(_ context.Context, _ rt.VMRef) error { return rt.ErrNotImplemented }

--- a/packages/runtime/k8s/adapter.go
+++ b/packages/runtime/k8s/adapter.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -22,6 +23,7 @@ import (
 // "<NamespacePrefix><tenant>". Defaults to "novanas-".
 type Adapter struct {
 	cs              kubernetes.Interface
+	dyn             dynamic.Interface
 	NamespacePrefix string
 
 	mu       sync.Mutex
@@ -34,6 +36,16 @@ func New(cs kubernetes.Interface) *Adapter {
 		NamespacePrefix: "novanas-",
 		watchers:        make(map[rt.Tenant][]chan rt.Event),
 	}
+}
+
+// WithDynamicClient wires the dynamic client used for resources the
+// adapter does not statically type (KubeVirt VirtualMachine today).
+// Splitting it from the constructor keeps the conformance suite —
+// which only exercises typed objects — usable with just a fake
+// kubernetes.Interface.
+func (a *Adapter) WithDynamicClient(dyn dynamic.Interface) *Adapter {
+	a.dyn = dyn
+	return a
 }
 
 func (a *Adapter) Name() string { return "k8s" }

--- a/packages/runtime/k8s/adapter_test.go
+++ b/packages/runtime/k8s/adapter_test.go
@@ -9,17 +9,24 @@ import (
 	"github.com/azrtydxb/novanas/packages/runtime/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestConformance(t *testing.T) {
 	conformance.Run(t, func(_ *testing.T) (rt.Adapter, func()) {
 		cs := fake.NewClientset()
-		a := k8s.New(cs)
-		// The fake client's reactor for Deployments populates Status
-		// from Spec on Create — so a freshly-created Deployment
-		// reports Ready replicas immediately. That's what the
-		// conformance suite needs (no wait for a real scheduler).
+		// The dynamic fake client backs the KubeVirt VirtualMachine
+		// path. We register the GVR list-kind explicitly so the fake
+		// client's tracker can route List/Watch on that resource.
+		scheme := runtime.NewScheme()
+		gvr := schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}
+		dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+			gvr: "VirtualMachineList",
+		})
+		a := k8s.New(cs).WithDynamicClient(dyn)
 		simulateDeploymentReady(cs)
 		return a, func() {}
 	})

--- a/packages/runtime/k8s/vm.go
+++ b/packages/runtime/k8s/vm.go
@@ -1,0 +1,178 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	rt "github.com/azrtydxb/novanas/packages/runtime"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+)
+
+// kubevirtVMGVR is the GroupVersionResource for KubeVirt VirtualMachine.
+// Pinned at v1; KubeVirt has been v1 since 0.36.
+var kubevirtVMGVR = schema.GroupVersionResource{
+	Group:    "kubevirt.io",
+	Version:  "v1",
+	Resource: "virtualmachines",
+}
+
+const kubevirtVMKind = "VirtualMachine"
+
+func (a *Adapter) ensureNamespace(ctx context.Context, t rt.Tenant) (string, error) {
+	ns := a.namespace(t)
+	if _, err := a.cs.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("%w: tenant %q not found", rt.ErrNotFound, t)
+		}
+		return "", err
+	}
+	return ns, nil
+}
+
+func (a *Adapter) vmClient(ns string) (dynamic.ResourceInterface, error) {
+	if a.dyn == nil {
+		return nil, errors.New("k8s adapter: dynamic client not configured")
+	}
+	return a.dyn.Resource(kubevirtVMGVR).Namespace(ns), nil
+}
+
+func (a *Adapter) EnsureVM(ctx context.Context, spec rt.VMSpec) (rt.VMStatus, error) {
+	if spec.Ref.Name == "" || spec.Ref.Tenant == "" {
+		return rt.VMStatus{}, fmt.Errorf("%w: vm name and tenant required", rt.ErrInvalidSpec)
+	}
+	ns, err := a.ensureNamespace(ctx, spec.Ref.Tenant)
+	if err != nil {
+		return rt.VMStatus{}, err
+	}
+	vc, err := a.vmClient(ns)
+	if err != nil {
+		return rt.VMStatus{}, err
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   kubevirtVMGVR.Group,
+		Version: kubevirtVMGVR.Version,
+		Kind:    kubevirtVMKind,
+	})
+	u.SetName(spec.Ref.Name)
+	u.SetNamespace(ns)
+	u.SetLabels(map[string]string{
+		labelTenant: string(spec.Ref.Tenant),
+		labelVM:     spec.Ref.Name,
+	})
+	if spec.Spec != nil {
+		buf, err := json.Marshal(spec.Spec)
+		if err != nil {
+			return rt.VMStatus{}, fmt.Errorf("kubevirt: marshal spec: %w", err)
+		}
+		var specMap map[string]any
+		if err := json.Unmarshal(buf, &specMap); err != nil {
+			return rt.VMStatus{}, fmt.Errorf("kubevirt: unmarshal spec: %w", err)
+		}
+		if err := unstructured.SetNestedField(u.Object, specMap, "spec"); err != nil {
+			return rt.VMStatus{}, fmt.Errorf("kubevirt: set nested spec: %w", err)
+		}
+	}
+
+	existing, getErr := vc.Get(ctx, spec.Ref.Name, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(getErr):
+		if _, err := vc.Create(ctx, u, metav1.CreateOptions{}); err != nil {
+			return rt.VMStatus{}, fmt.Errorf("kubevirt: create: %w", err)
+		}
+	case getErr != nil:
+		return rt.VMStatus{}, fmt.Errorf("kubevirt: get: %w", getErr)
+	default:
+		u.SetResourceVersion(existing.GetResourceVersion())
+		if _, err := vc.Update(ctx, u, metav1.UpdateOptions{}); err != nil {
+			return rt.VMStatus{}, fmt.Errorf("kubevirt: update: %w", err)
+		}
+	}
+
+	return rt.VMStatus{Ref: spec.Ref, Phase: phaseFromVM(u)}, nil
+}
+
+func (a *Adapter) DeleteVM(ctx context.Context, ref rt.VMRef) error {
+	ns := a.namespace(ref.Tenant)
+	vc, err := a.vmClient(ns)
+	if err != nil {
+		return err
+	}
+	if err := vc.Delete(ctx, ref.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func (a *Adapter) ObserveVM(ctx context.Context, ref rt.VMRef) (rt.VMStatus, error) {
+	ns := a.namespace(ref.Tenant)
+	vc, err := a.vmClient(ns)
+	if err != nil {
+		return rt.VMStatus{}, err
+	}
+	u, err := vc.Get(ctx, ref.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return rt.VMStatus{}, rt.ErrNotFound
+		}
+		return rt.VMStatus{}, err
+	}
+	return rt.VMStatus{Ref: ref, Phase: phaseFromVM(u)}, nil
+}
+
+func (a *Adapter) SetVMPowerState(ctx context.Context, ref rt.VMRef, state rt.VMPowerState) error {
+	ns := a.namespace(ref.Tenant)
+	vc, err := a.vmClient(ns)
+	if err != nil {
+		return err
+	}
+	running := state == rt.VMRunning
+	patch := fmt.Appendf(nil, `{"spec":{"running":%t}}`, running)
+	if _, err := vc.Patch(ctx, ref.Name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return rt.ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// RestartVM triggers a hard restart by toggling spec.running off then
+// on. Equivalent to KubeVirt's restart subresource without needing the
+// typed client.
+func (a *Adapter) RestartVM(ctx context.Context, ref rt.VMRef) error {
+	if err := a.SetVMPowerState(ctx, ref, rt.VMStopped); err != nil {
+		return err
+	}
+	return a.SetVMPowerState(ctx, ref, rt.VMRunning)
+}
+
+func phaseFromVM(u *unstructured.Unstructured) rt.VMPowerState {
+	if u == nil {
+		return rt.VMStopped
+	}
+	if running, found, _ := unstructured.NestedBool(u.Object, "spec", "running"); found && running {
+		if printable, ok, _ := unstructured.NestedString(u.Object, "status", "printableStatus"); ok && printable != "" {
+			switch printable {
+			case "Running":
+				return rt.VMRunning
+			case "Paused":
+				return rt.VMPaused
+			default:
+				return rt.VMStopped
+			}
+		}
+		return rt.VMRunning
+	}
+	return rt.VMStopped
+}
+
+const labelVM = "novanas.io/vm"

--- a/packages/runtime/memory/adapter.go
+++ b/packages/runtime/memory/adapter.go
@@ -16,6 +16,7 @@ type Adapter struct {
 	tenants   map[rt.Tenant]struct{}
 	networks  map[networkKey]rt.NetworkSpec
 	workloads map[workloadKey]workloadEntry
+	vms       map[vmKey]vmEntry
 	watchers  map[rt.Tenant][]chan rt.Event
 }
 
@@ -34,11 +35,22 @@ type workloadEntry struct {
 	status rt.WorkloadStatus
 }
 
+type vmKey struct {
+	tenant rt.Tenant
+	name   string
+}
+
+type vmEntry struct {
+	spec   rt.VMSpec
+	status rt.VMStatus
+}
+
 func New() *Adapter {
 	return &Adapter{
 		tenants:   make(map[rt.Tenant]struct{}),
 		networks:  make(map[networkKey]rt.NetworkSpec),
 		workloads: make(map[workloadKey]workloadEntry),
+		vms:       make(map[vmKey]vmEntry),
 		watchers:  make(map[rt.Tenant][]chan rt.Event),
 	}
 }
@@ -195,6 +207,67 @@ func (a *Adapter) fanout(tenant rt.Tenant, ev rt.Event) {
 		default:
 		}
 	}
+}
+
+func (a *Adapter) EnsureVM(_ context.Context, spec rt.VMSpec) (rt.VMStatus, error) {
+	if spec.Ref.Name == "" || spec.Ref.Tenant == "" {
+		return rt.VMStatus{}, fmt.Errorf("%w: vm name and tenant required", rt.ErrInvalidSpec)
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if _, ok := a.tenants[spec.Ref.Tenant]; !ok {
+		return rt.VMStatus{}, fmt.Errorf("%w: tenant %q not found", rt.ErrNotFound, spec.Ref.Tenant)
+	}
+	prev, existed := a.vms[vmKey{spec.Ref.Tenant, spec.Ref.Name}]
+	phase := rt.VMRunning
+	if existed {
+		phase = prev.status.Phase
+	}
+	status := rt.VMStatus{Ref: spec.Ref, Phase: phase}
+	a.vms[vmKey{spec.Ref.Tenant, spec.Ref.Name}] = vmEntry{spec: spec, status: status}
+	return status, nil
+}
+
+func (a *Adapter) DeleteVM(_ context.Context, ref rt.VMRef) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.vms, vmKey{ref.Tenant, ref.Name})
+	return nil
+}
+
+func (a *Adapter) ObserveVM(_ context.Context, ref rt.VMRef) (rt.VMStatus, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	entry, ok := a.vms[vmKey{ref.Tenant, ref.Name}]
+	if !ok {
+		return rt.VMStatus{}, rt.ErrNotFound
+	}
+	return entry.status, nil
+}
+
+func (a *Adapter) SetVMPowerState(_ context.Context, ref rt.VMRef, state rt.VMPowerState) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	entry, ok := a.vms[vmKey{ref.Tenant, ref.Name}]
+	if !ok {
+		return rt.ErrNotFound
+	}
+	entry.status.Phase = state
+	a.vms[vmKey{ref.Tenant, ref.Name}] = entry
+	return nil
+}
+
+func (a *Adapter) RestartVM(_ context.Context, ref rt.VMRef) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	entry, ok := a.vms[vmKey{ref.Tenant, ref.Name}]
+	if !ok {
+		return rt.ErrNotFound
+	}
+	entry.status.Phase = rt.VMRunning
+	entry.status.Message = "restarted"
+	a.vms[vmKey{ref.Tenant, ref.Name}] = entry
+	return nil
 }
 
 func validate(spec rt.WorkloadSpec) error {

--- a/packages/runtime/types.go
+++ b/packages/runtime/types.go
@@ -164,3 +164,32 @@ type LogOptions struct {
 	Follow    bool
 	TailLines int64
 }
+
+type VMRef struct {
+	Tenant Tenant
+	Name   string
+}
+
+// VMSpec is a runtime-neutral description of a virtual machine. Spec is
+// kept as a free-form map so the K8s adapter can pass through KubeVirt
+// VirtualMachineSpec shapes without the runtime package having to model
+// every KubeVirt field. A typed surface can be added once a Docker
+// (libvirt) adapter exists and the union of fields is known.
+type VMSpec struct {
+	Ref  VMRef
+	Spec map[string]any
+}
+
+type VMPowerState string
+
+const (
+	VMRunning VMPowerState = "Running"
+	VMStopped VMPowerState = "Stopped"
+	VMPaused  VMPowerState = "Paused"
+)
+
+type VMStatus struct {
+	Ref     VMRef
+	Phase   VMPowerState
+	Message string
+}


### PR DESCRIPTION
## Summary

Extends `runtime.Adapter` with the five-method surface NovaNas needs to manage virtual machines independent of the operator-side `KubeVirtEngine`: `EnsureVM`, `DeleteVM`, `ObserveVM`, `SetVMPowerState`, `RestartVM`.

`VMSpec.Spec` is intentionally `map[string]any` so the K8s adapter can pass through KubeVirt `VirtualMachineSpec` shapes without the runtime package modelling every field — a typed surface can be added once a Docker (libvirt) adapter exists and the union of fields is known.

## Implementations

**memory** — full in-process state machine; `SetVMPowerState` mutates `Phase`, `RestartVM` resets to Running.

**k8s** — backed by KubeVirt via the dynamic client. `EnsureVM` creates/updates a `kubevirt.io/v1 VirtualMachine`; `SetVMPowerState` patches `spec.running`; `RestartVM` toggles `spec.running` off then on (matches KubeVirt's restart subresource semantics without needing the typed kubevirt scheme). Constructor stays narrow: `WithDynamicClient` is opt-in so the conformance suite can use just `kubernetes.Interface` for everything else.

**docker** — stubs returning `ErrNotImplemented`; libvirt path lands when the docker adapter does.

## Conformance

`TestConformance/VMLifecycle` exercises the full ensure → set state → restart → observe → delete flow. `ErrNotImplemented` makes the subtest skip (docker stubs).

## Tests

- `runtime/k8s` tests wire `dynamicfake.NewSimpleDynamicClient` with a custom list-kind for `kubevirt.io/v1/virtualmachines` so the fake backs Create/Get/Delete/Patch
- memory + k8s conformance pass; docker subtests skip cleanly

## What this unblocks

PR 11 migrates the `vm` resource Crd→Pg and rewrites `VmReconciler` against this adapter surface. No operator/API changes in this PR.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean — VM conformance passes against memory + k8s
- [x] `golangci-lint run` clean across all 6 modules
- [ ] CI lint-go, lint-ts, typecheck, build, test all green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)