### PR TITLE
feat(runtime/k8s): implement Logs and Exec (PR 13)

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -43,6 +43,7 @@ github.com/google/cel-go v0.26.0/go.mod h1:A9O8OU9rdvrK5MQyrqfIxo1a0u4g3sF8KB6PU
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
@@ -54,8 +55,10 @@ github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7X
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
 github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183/go.mod h1:4VWG+W22wrB4HfBL88P40DxLEpSOaiBVxUnfalfJo9k=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=

--- a/packages/runtime/k8s/adapter.go
+++ b/packages/runtime/k8s/adapter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -15,6 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	utilexec "k8s.io/client-go/util/exec"
 )
 
 // Adapter implements runtime.Adapter against a Kubernetes cluster.
@@ -24,17 +28,24 @@ import (
 type Adapter struct {
 	cs              kubernetes.Interface
 	dyn             dynamic.Interface
+	cfg             *rest.Config
+	executor        execFactory
 	NamespacePrefix string
 
 	mu       sync.Mutex
 	watchers map[rt.Tenant][]chan rt.Event
 }
 
+// execFactory wraps remotecommand.NewSPDYExecutor so tests can swap
+// in a fake. Production wiring goes through realExecFactory below.
+type execFactory func(cfg *rest.Config, method string, url *url.URL) (remotecommand.Executor, error)
+
 func New(cs kubernetes.Interface) *Adapter {
 	return &Adapter{
 		cs:              cs,
 		NamespacePrefix: "novanas-",
 		watchers:        make(map[rt.Tenant][]chan rt.Event),
+		executor:        realExecFactory,
 	}
 }
 
@@ -46,6 +57,24 @@ func New(cs kubernetes.Interface) *Adapter {
 func (a *Adapter) WithDynamicClient(dyn dynamic.Interface) *Adapter {
 	a.dyn = dyn
 	return a
+}
+
+// WithRestConfig wires the *rest.Config required for streaming
+// endpoints (Logs, Exec). The conformance suite uses a fake clientset
+// and skips Logs/Exec, so this is opt-in.
+func (a *Adapter) WithRestConfig(cfg *rest.Config) *Adapter {
+	a.cfg = cfg
+	return a
+}
+
+// WithExecutor lets tests substitute the SPDY executor factory.
+func (a *Adapter) WithExecutor(f execFactory) *Adapter {
+	a.executor = f
+	return a
+}
+
+func realExecFactory(cfg *rest.Config, method string, u *url.URL) (remotecommand.Executor, error) {
+	return remotecommand.NewSPDYExecutor(cfg, method, u)
 }
 
 func (a *Adapter) Name() string { return "k8s" }
@@ -212,12 +241,101 @@ func (a *Adapter) ObserveWorkload(ctx context.Context, ref rt.WorkloadRef) (rt.W
 	return rt.WorkloadStatus{}, rt.ErrNotFound
 }
 
-func (a *Adapter) Logs(_ context.Context, _ rt.LogOptions, _ io.Writer) error {
-	return rt.ErrNotImplemented
+// Logs streams a workload's container log into out. We resolve the
+// workload to its Pod by label-selector (the same labels EnsureWorkload
+// stamps), then call CoreV1().Pods.GetLogs on the first match. Picking
+// the first replica is a deliberate simplification — multi-pod log
+// fanout belongs to a higher layer.
+func (a *Adapter) Logs(ctx context.Context, opts rt.LogOptions, out io.Writer) error {
+	nsName := a.namespace(opts.Ref.Tenant)
+	pods, err := a.cs.CoreV1().Pods(nsName).List(ctx, metav1.ListOptions{
+		LabelSelector: labelWorkload + "=" + opts.Ref.Name,
+		Limit:         1,
+	})
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return rt.ErrNotFound
+	}
+	pod := pods.Items[0]
+	logOpts := &corev1.PodLogOptions{Follow: opts.Follow, Container: opts.Container}
+	if opts.TailLines > 0 {
+		logOpts.TailLines = &opts.TailLines
+	}
+	req := a.cs.CoreV1().Pods(nsName).GetLogs(pod.Name, logOpts)
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+	_, err = io.Copy(out, stream)
+	return err
 }
 
-func (a *Adapter) Exec(_ context.Context, _ rt.ExecRequest, _, _ io.Writer) (int, error) {
-	return -1, rt.ErrNotImplemented
+// Exec runs a one-shot command in the named workload's first matching
+// pod. Streams stdout / stderr through the writers. Requires a
+// *rest.Config (WithRestConfig) since SPDY streaming bypasses the
+// typed clientset.
+func (a *Adapter) Exec(ctx context.Context, req rt.ExecRequest, stdout, stderr io.Writer) (int, error) {
+	if a.cfg == nil {
+		return -1, fmt.Errorf("k8s adapter: rest.Config required for Exec (call WithRestConfig)")
+	}
+	nsName := a.namespace(req.Ref.Tenant)
+	pods, err := a.cs.CoreV1().Pods(nsName).List(ctx, metav1.ListOptions{
+		LabelSelector: labelWorkload + "=" + req.Ref.Name,
+		Limit:         1,
+	})
+	if err != nil {
+		return -1, err
+	}
+	if len(pods.Items) == 0 {
+		return -1, rt.ErrNotFound
+	}
+	pod := pods.Items[0]
+	container := req.Container
+	if container == "" && len(pod.Spec.Containers) > 0 {
+		container = pod.Spec.Containers[0].Name
+	}
+	host := strings.TrimRight(a.cfg.Host, "/")
+	u, err := url.Parse(fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/exec", host, nsName, pod.Name))
+	if err != nil {
+		return -1, err
+	}
+	q := u.Query()
+	if container != "" {
+		q.Set("container", container)
+	}
+	for _, c := range req.Command {
+		q.Add("command", c)
+	}
+	if stdout != nil {
+		q.Set("stdout", "true")
+	}
+	if stderr != nil {
+		q.Set("stderr", "true")
+	}
+	if req.TTY {
+		q.Set("tty", "true")
+	}
+	u.RawQuery = q.Encode()
+	executor, err := a.executor(a.cfg, "POST", u)
+	if err != nil {
+		return -1, err
+	}
+	streamErr := executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: stdout,
+		Stderr: stderr,
+		Tty:    req.TTY,
+	})
+	if streamErr != nil {
+		var codeErr utilexec.CodeExitError
+		if errors.As(streamErr, &codeErr) {
+			return codeErr.Code, nil
+		}
+		return -1, streamErr
+	}
+	return 0, nil
 }
 
 func (a *Adapter) WatchEvents(ctx context.Context, t rt.Tenant) (<-chan rt.Event, error) {

--- a/packages/runtime/k8s/logs_exec_test.go
+++ b/packages/runtime/k8s/logs_exec_test.go
@@ -1,0 +1,158 @@
+package k8s_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	rt "github.com/azrtydxb/novanas/packages/runtime"
+	"github.com/azrtydxb/novanas/packages/runtime/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// TestLogs_NoMatchingPod verifies that Logs returns ErrNotFound when
+// no pod carries the workload label — the same property exercised by
+// the conformance suite, but exercised here against the K8s adapter
+// specifically since the fake clientset doesn't auto-spawn Pods from
+// Deployments.
+func TestLogs_NoMatchingPod(t *testing.T) {
+	cs := fake.NewClientset()
+	a := k8s.New(cs)
+	ctx := context.Background()
+	if err := a.EnsureTenant(ctx, "alpha"); err != nil {
+		t.Fatalf("EnsureTenant: %v", err)
+	}
+	var buf bytes.Buffer
+	err := a.Logs(ctx, rt.LogOptions{Ref: rt.WorkloadRef{Tenant: "alpha", Name: "ghost"}}, &buf)
+	if !errors.Is(err, rt.ErrNotFound) {
+		t.Fatalf("Logs(missing pod) = %v, want ErrNotFound", err)
+	}
+}
+
+// TestLogs_StreamsFromPod creates a labeled Pod by hand (since the
+// fake clientset doesn't synthesize Pods from Deployments), then
+// asserts Logs streams without error. The fake's GetLogs returns an
+// empty stream — that's fine for this test; we only care that the
+// pod-resolution + stream wiring runs cleanly.
+func TestLogs_StreamsFromPod(t *testing.T) {
+	cs := fake.NewClientset()
+	a := k8s.New(cs)
+	ctx := context.Background()
+	if err := a.EnsureTenant(ctx, "alpha"); err != nil {
+		t.Fatalf("EnsureTenant: %v", err)
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "echo-abc",
+			Namespace: "novanas-alpha",
+			Labels: map[string]string{
+				"novanas.io/tenant":   "alpha",
+				"novanas.io/workload": "echo",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Image: "echo:latest"}},
+		},
+	}
+	if _, err := cs.CoreV1().Pods("novanas-alpha").Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed pod: %v", err)
+	}
+	var buf bytes.Buffer
+	err := a.Logs(ctx, rt.LogOptions{Ref: rt.WorkloadRef{Tenant: "alpha", Name: "echo"}}, &buf)
+	if err != nil {
+		t.Fatalf("Logs: %v", err)
+	}
+}
+
+// TestExec_NoConfig verifies Exec rejects with a clear error when no
+// rest.Config is wired (the conformance suite path).
+func TestExec_NoConfig(t *testing.T) {
+	cs := fake.NewClientset()
+	a := k8s.New(cs)
+	ctx := context.Background()
+	if err := a.EnsureTenant(ctx, "alpha"); err != nil {
+		t.Fatalf("EnsureTenant: %v", err)
+	}
+	_, err := a.Exec(ctx, rt.ExecRequest{Ref: rt.WorkloadRef{Tenant: "alpha", Name: "echo"}, Command: []string{"true"}}, nil, nil)
+	if err == nil {
+		t.Fatal("Exec without rest.Config should error")
+	}
+}
+
+// TestExec_NoMatchingPod confirms Exec maps a missing pod to
+// ErrNotFound rather than a transport-level error.
+func TestExec_NoMatchingPod(t *testing.T) {
+	cs := fake.NewClientset()
+	a := k8s.New(cs).WithRestConfig(&rest.Config{Host: "https://example.invalid"})
+	ctx := context.Background()
+	if err := a.EnsureTenant(ctx, "alpha"); err != nil {
+		t.Fatalf("EnsureTenant: %v", err)
+	}
+	_, err := a.Exec(ctx, rt.ExecRequest{Ref: rt.WorkloadRef{Tenant: "alpha", Name: "ghost"}, Command: []string{"true"}}, nil, nil)
+	if !errors.Is(err, rt.ErrNotFound) {
+		t.Fatalf("Exec(missing pod) = %v, want ErrNotFound", err)
+	}
+}
+
+// TestExec_StreamsViaFakeExecutor exercises the full Exec wiring with
+// a fake SPDY executor so we cover the URL build, executor factory
+// call, and StreamWithContext error mapping without needing a real
+// kube-apiserver.
+func TestExec_StreamsViaFakeExecutor(t *testing.T) {
+	cs := fake.NewClientset()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "echo-abc",
+			Namespace: "novanas-alpha",
+			Labels:    map[string]string{"novanas.io/workload": "echo"},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+	}
+	ctx := context.Background()
+	a := k8s.New(cs).WithRestConfig(&rest.Config{Host: "https://example.invalid"}).
+		WithExecutor(func(_ *rest.Config, _ string, _ *url.URL) (remotecommand.Executor, error) {
+			return fakeExecutor{stdout: []byte("hello\n")}, nil
+		})
+	if err := a.EnsureTenant(ctx, "alpha"); err != nil {
+		t.Fatalf("EnsureTenant: %v", err)
+	}
+	if _, err := cs.CoreV1().Pods("novanas-alpha").Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed pod: %v", err)
+	}
+	var stdout bytes.Buffer
+	code, err := a.Exec(ctx, rt.ExecRequest{
+		Ref:     rt.WorkloadRef{Tenant: "alpha", Name: "echo"},
+		Command: []string{"echo", "hello"},
+	}, &stdout, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("Exec exit code = %d, want 0", code)
+	}
+	if got := stdout.String(); got != "hello\n" {
+		t.Fatalf("stdout = %q, want %q", got, "hello\n")
+	}
+}
+
+type fakeExecutor struct {
+	stdout []byte
+}
+
+func (f fakeExecutor) Stream(_ remotecommand.StreamOptions) error { return nil }
+
+func (f fakeExecutor) StreamWithContext(_ context.Context, opts remotecommand.StreamOptions) error {
+	if opts.Stdout != nil && len(f.stdout) > 0 {
+		_, err := opts.Stdout.Write(f.stdout)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Replaces the `ErrNotImplemented` stubs from PR 8 with real `client-go`-backed `Logs` and `Exec`.

## Logs

- Resolve workload → Pod by label-selector (`novanas.io/workload`).
- `GetLogs` + `Stream` into the caller's writer. Honours `Follow`, `Container`, `TailLines`.
- Returns `ErrNotFound` when no Pod carries the workload label.

## Exec

- Same pod-resolution path; first container by default.
- URL built directly from `rest.Config.Host` (sidesteps the fake clientset's RESTClient stub which panics).
- SPDY executor factory is opt-in via `WithExecutor` for tests; production wires through `remotecommand.NewSPDYExecutor`.
- Maps `utilexec.CodeExitError` to a clean exit-code return.

## Adapter constructor

- `WithRestConfig(cfg)` — required for Exec, opt-in.
- `WithExecutor(f)` — test seam for the SPDY factory.

## Tests

- `TestLogs_NoMatchingPod` / `TestLogs_StreamsFromPod` — fake clientset with hand-seeded Pod.
- `TestExec_NoConfig`, `TestExec_NoMatchingPod`, `TestExec_StreamsViaFakeExecutor` — full Exec wiring with a hand-rolled fake executor; verifies stdout pass-through and exit-code 0.

## Drive-by (sweep-in)

Two unrelated storage edits got picked up by the commit:
- `storage/cmd/controller/Dockerfile`: COPY `packages/sdk/go-client/` so the controller image can reach the SDK at build time (it already imports it after #50).
- `storage/internal/controller/pool_poller.go`: graceful no-op when `BackendAssignment` CRD isn't registered (matches the zero-CRD direction; no-op until that endpoint moves to the API server). Also tidies an `errors` ↔ `apierrors` import shadow.

## Test plan

- [x] `go build ./...` clean across all 6 modules
- [x] `go test ./...` clean — 5 new K8s-specific tests pass
- [x] `golangci-lint run` clean
- [ ] CI lint-go, lint-ts, typecheck, build, test all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)