### PR TITLE
chore(api): disable auth/RBAC stack to unblock storage testing

### DIFF
--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -123,9 +123,4 @@ describe('NovaNas API app', () => {
     expect(body.version).toBe('0.0.0-test');
     expect(body.apiVersion).toBe('v1');
   });
-
-  it('GET /api/v1/pools without session returns 401', async () => {
-    const res = await built.app.inject({ method: 'GET', url: '/api/v1/pools' });
-    expect(res.statusCode).toBe(401);
-  });
 });

--- a/packages/api/src/auth/authz.ts
+++ b/packages/api/src/auth/authz.ts
@@ -245,80 +245,21 @@ export function isShareOnly(user: AuthenticatedUser): boolean {
   );
 }
 
-function canAccess(
-  user: AuthenticatedUser,
-  action: Action,
-  kind: Kind,
-  namespace?: string
-): boolean {
-  if (!user || isShareOnly(user)) return false;
-
-  // Service accounts (TokenReview-authenticated internal callers) take
-  // a separate path with kind-targeted write grants.
-  if (isInternalServiceAccount(user)) {
-    return internalCanAccess(user, action, kind);
-  }
-
-  const admin = hasAnyRole(user, [AuthzRole.Admin]);
-  const regular = hasAnyRole(user, [AuthzRole.User]);
-  const viewer = hasAnyRole(user, [AuthzRole.Viewer]);
-
-  if (admin) return true;
-
-  if (action === 'read') {
-    if (viewer || regular) return true;
-    return false;
-  }
-
-  // write or delete
-  if (!regular) return false;
-  if (ADMIN_ONLY_WRITE.has(kind)) return false;
-  if (isCluster(kind)) {
-    // cluster-scoped kinds the user CAN touch (Dataset, Bucket, Snapshot)
-    // are only writable in their own labelled scope; we can't express that
-    // purely with authz at the edge, so accept and let Kubernetes RBAC enforce.
-    return true;
-  }
-  // namespaced kind (AppInstance) — must match the user's own namespace
-  if (!namespace) return false;
-  return namespace === ownNamespace(user);
+// AUTH IS DISABLED — every gate returns true so the route surface is
+// wide open. See plugins/auth.ts for the synthetic-admin injection
+// that pairs with this, and the GitHub issue tracking re-enablement.
+export function canRead(_u: AuthenticatedUser, _k: Kind, _ns?: string): boolean {
+  return true;
 }
 
-export function canRead(user: AuthenticatedUser, kind: Kind, namespace?: string): boolean {
-  return canAccess(user, 'read', kind, namespace);
+export function canWrite(_u: AuthenticatedUser, _k: Kind, _ns?: string): boolean {
+  return true;
 }
 
-export function canWrite(user: AuthenticatedUser, kind: Kind, namespace?: string): boolean {
-  return canAccess(user, 'write', kind, namespace);
+export function canDelete(_u: AuthenticatedUser, _k: Kind, _ns?: string): boolean {
+  return true;
 }
 
-export function canDelete(user: AuthenticatedUser, kind: Kind, namespace?: string): boolean {
-  return canAccess(user, 'delete', kind, namespace);
-}
-
-/**
- * Action-level authorization check used by E1-API-Actions.
- *
- * Model:
- *  - Admin: any action on any resource.
- *  - User: actions on resources within their own namespace (namespaced kinds),
- *    or any action on user-writable cluster-scoped kinds.
- *  - Viewer / share-only: 403 on all actions.
- *
- * Destructive actions (`delete`) additionally require canDelete() to pass.
- */
-export function canAction(
-  user: AuthenticatedUser,
-  kind: Kind,
-  action: string,
-  namespace?: string
-): boolean {
-  if (!user || isShareOnly(user)) return false;
-  if (hasAnyRole(user, [AuthzRole.Admin])) return true;
-  if (hasAnyRole(user, [AuthzRole.Viewer]) && !hasAnyRole(user, [AuthzRole.User])) return false;
-  // destructive actions require delete rights
-  if (action === 'delete' || action === 'destroy') {
-    return canDelete(user, kind, namespace);
-  }
-  return canWrite(user, kind, namespace);
+export function canAction(_u: AuthenticatedUser, _k: Kind, _action: string, _ns?: string): boolean {
+  return true;
 }

--- a/packages/api/src/auth/decorators.ts
+++ b/packages/api/src/auth/decorators.ts
@@ -1,34 +1,23 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { hasRole } from './rbac.js';
 
 /**
- * Fastify decorators for `request.user`. The `auth` plugin populates
- * `request.user` on the preHandler lifecycle if a valid session cookie
- * is present. These helpers enforce presence on individual routes.
+ * AUTH IS DISABLED. The pre-handlers below are no-ops; `plugins/auth.ts`
+ * always populates `request.user` with a synthetic admin so call sites
+ * can keep their `req.user` references unchanged. Re-enabling means
+ * restoring the cookie/Bearer paths in `plugins/auth.ts` and turning
+ * these pre-handlers back into real checks.
  */
 
 export function requireAuth(
-  req: FastifyRequest,
-  reply: FastifyReply,
+  _req: FastifyRequest,
+  _reply: FastifyReply,
   done: (err?: Error) => void
 ): void {
-  if (!req.user) {
-    reply.code(401).send({ error: 'unauthorized', message: 'authentication required' });
-    return;
-  }
   done();
 }
 
-export function requireRole(role: string) {
-  return (req: FastifyRequest, reply: FastifyReply, done: (err?: Error) => void): void => {
-    if (!req.user) {
-      reply.code(401).send({ error: 'unauthorized' });
-      return;
-    }
-    if (!hasRole(req.user, role)) {
-      reply.code(403).send({ error: 'forbidden', message: `missing role: ${role}` });
-      return;
-    }
+export function requireRole(_role: string) {
+  return (_req: FastifyRequest, _reply: FastifyReply, done: (err?: Error) => void): void => {
     done();
   };
 }

--- a/packages/api/src/auth/rbac.ts
+++ b/packages/api/src/auth/rbac.ts
@@ -40,17 +40,12 @@ export function userFromClaims(claims: Record<string, unknown>): AuthenticatedUs
   };
 }
 
-export function hasRole(user: AuthenticatedUser, role: string): boolean {
-  // Realm roles arrive in two places depending on which token surfaced
-  // them: realm_access.roles → user.roles, and the novanas:roles
-  // mapper → user.groups. Search both. Accept either the bare name or
-  // the historical "novanas:" prefix the constants used to emit.
-  const haystack = [...(user.roles ?? []), ...(user.groups ?? [])];
-  const bare = role.startsWith(LEGACY_PREFIX) ? role.slice(LEGACY_PREFIX.length) : role;
-  const prefixed = `${LEGACY_PREFIX}${bare}`;
-  return haystack.includes(bare) || haystack.includes(prefixed);
+// AUTH IS DISABLED — these always allow. See plugins/auth.ts for the
+// matching admin-injection.
+export function hasRole(_user: AuthenticatedUser, _role: string): boolean {
+  return true;
 }
 
-export function hasAnyRole(user: AuthenticatedUser, roles: string[]): boolean {
-  return roles.some((r) => hasRole(user, r));
+export function hasAnyRole(_user: AuthenticatedUser, _roles: string[]): boolean {
+  return true;
 }

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -1,62 +1,50 @@
 import type { AuthenticationV1Api } from '@kubernetes/client-node';
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { registerAuthDecorators } from '../auth/decorators.js';
-import { userFromClaims } from '../auth/rbac.js';
 import type { SessionStore } from '../auth/session.js';
-import { buildTokenReviewMiddleware } from '../auth/tokenreview.js';
 import type { Env } from '../env.js';
 import type { AuthenticatedUser } from '../types.js';
 
 /**
- * Authentication plugin. Attaches `request.user` from one of:
- *   1. A signed session cookie (browser SPA)
- *   2. A Bearer token validated via Kubernetes TokenReview (in-cluster
- *      service accounts: disk-agent, storage-meta, …)
+ * AUTH IS DISABLED. Every request is treated as an authenticated admin.
+ * The session-cookie + Bearer/TokenReview paths from the original
+ * implementation are gone; route call sites and tests still see a
+ * populated `req.user` so they don't have to change.
  *
- * Does NOT enforce — routes opt in via `requireAuth` preHandler.
+ * Re-enabling means restoring the cookie-then-Bearer fallthrough that
+ * was here previously. The Keycloak realm + OIDC routes (login,
+ * callback, logout, device-code, token, me) in `routes/auth.ts` are
+ * intentionally kept intact so flipping back doesn't require
+ * re-deriving infrastructure.
+ *
+ * Tracking: see the GitHub issue created alongside this change.
  */
+
 export interface AuthPluginOptions {
   env: Env;
   store: SessionStore;
   /**
-   * Kubernetes Authentication v1 client. When omitted, Bearer tokens
-   * are not validated and only session-cookie auth is available
-   * (useful for tests).
+   * Kept on the type so callers don't have to change. Currently unused;
+   * the plugin no longer consults Kubernetes TokenReview.
    */
   authnApi?: AuthenticationV1Api;
 }
 
-export async function registerAuth(app: FastifyInstance, opts: AuthPluginOptions): Promise<void> {
-  const { env, store, authnApi } = opts;
+const DISABLED_ADMIN: AuthenticatedUser = {
+  sub: 'auth-disabled',
+  username: 'admin',
+  email: 'admin@novanas.local',
+  name: 'NovaNas Admin (auth disabled)',
+  groups: ['/admins', 'admins', 'admin'],
+  roles: ['admin', 'user'],
+  tenant: 'default',
+  claims: { auth_disabled: true },
+};
+
+export async function registerAuth(app: FastifyInstance, _opts: AuthPluginOptions): Promise<void> {
   registerAuthDecorators(app);
 
-  const tokenReview = authnApi ? buildTokenReviewMiddleware({ api: authnApi }) : null;
-
-  app.addHook('preHandler', async (req: FastifyRequest, reply) => {
-    // 1. Session cookie (browser).
-    const sid = req.cookies?.[env.SESSION_COOKIE_NAME];
-    if (sid) {
-      const unsigned = req.unsignCookie(sid);
-      if (unsigned.valid && unsigned.value) {
-        const session = await store.touch(unsigned.value);
-        if (session) {
-          req.sessionId = unsigned.value;
-          req.user = userFromClaims(session.claims);
-          return;
-        }
-      }
-    }
-    // 2. Bearer token (in-cluster service account). Only attempt if
-    //    the header is present so unauthenticated SPA requests don't
-    //    pay the TokenReview round-trip.
-    const authz = req.headers.authorization ?? '';
-    if (tokenReview && authz.toLowerCase().startsWith('bearer ')) {
-      // tokenReview.authenticate writes `req.user` on success or
-      // sends a 401/403 reply itself on failure. Either way, downstream
-      // handlers won't run if reply was sent.
-      await tokenReview.authenticate(req, reply);
-      const u = (req as FastifyRequest & { user?: AuthenticatedUser }).user;
-      if (u) return;
-    }
+  app.addHook('preHandler', async (req: FastifyRequest) => {
+    (req as FastifyRequest & { user: AuthenticatedUser }).user = DISABLED_ADMIN;
   });
 }

--- a/packages/api/src/resources/alert-channels.test.ts
+++ b/packages/api/src/resources/alert-channels.test.ts
@@ -23,16 +23,6 @@ describe('alert-channels resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/alert-channels',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing AlertChannel', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('alert-channels resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/alert-channels' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/alert-policies.test.ts
+++ b/packages/api/src/resources/alert-policies.test.ts
@@ -23,16 +23,6 @@ describe('alert-policies resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/alert-policies',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing AlertPolicy', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('alert-policies resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/alert-policies' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/api-tokens.test.ts
+++ b/packages/api/src/resources/api-tokens.test.ts
@@ -23,16 +23,6 @@ describe('api-tokens resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/api-tokens',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing ApiToken', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('api-tokens resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/api-tokens' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/app-catalogs.test.ts
+++ b/packages/api/src/resources/app-catalogs.test.ts
@@ -51,16 +51,6 @@ describe('app-catalogs resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('non-admin cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/app-catalogs',
-      headers: { cookie: cookieFor(h.built, userSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'cat-c' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/apps-actions.test.ts
+++ b/packages/api/src/resources/apps-actions.test.ts
@@ -63,15 +63,6 @@ describe('apps action routes (E1-API-Actions)', () => {
     expect(good.statusCode).toBe(200);
   });
 
-  it('viewer gets 403 on actions', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/apps/user-alice/jelly/start',
-      headers: { cookie: cookieFor(h.built, viewerSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 when target does not exist', async () => {
     const r = await h.built.app.inject({
       method: 'POST',

--- a/packages/api/src/resources/apps.test.ts
+++ b/packages/api/src/resources/apps.test.ts
@@ -15,14 +15,14 @@ describe('apps resource (namespaced)', () => {
   let h: TestAppHandle;
   let adminSid: string;
   let aliceSid: string;
-  let shareOnlySid: string;
 
   beforeAll(async () => {
     h = await buildTestApp();
-    await h.kube.seed('appinstances', sampleFor('alice', 'app-a'), 'user-alice');
+    // With auth disabled, every request resolves to the synthetic admin user,
+    // so namespace scoping always uses `user-admin`.
+    await h.kube.seed('appinstances', sampleFor('admin', 'app-a'), 'user-admin');
     adminSid = await h.authAs({ username: 'admin', roles: [AuthzRole.Admin] });
     aliceSid = await h.authAs({ username: 'alice', roles: [AuthzRole.User] });
-    shareOnlySid = await h.authAs({ username: 'bob', roles: [AuthzRole.ShareOnly] });
   });
   afterAll(async () => h.built.app.close());
 
@@ -66,24 +66,14 @@ describe('apps resource (namespaced)', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('share-only role cannot read (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/apps',
-      headers: { cookie: cookieFor(h.built, shareOnlySid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('admin sees their own namespace too', async () => {
-    // Admin lookup reads from `user-admin` namespace (empty → empty list)
     const r = await h.built.app.inject({
       method: 'GET',
       url: '/api/v1/apps',
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(200);
-    expect((r.json() as { items: unknown[] }).items).toHaveLength(0);
+    expect((r.json() as { items: unknown[] }).items.length).toBeGreaterThanOrEqual(1);
   });
 
   it('404 missing', async () => {

--- a/packages/api/src/resources/audit-policy.test.ts
+++ b/packages/api/src/resources/audit-policy.test.ts
@@ -34,16 +34,6 @@ describe('audit-policy resource', () => {
     expect([400, 404]).toContain(r.statusCode);
   });
 
-  it('returns 403 for share-only on GET', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/audit-policy',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('does not expose DELETE', async () => {
     const r = await h.built.app.inject({
       method: 'DELETE',
@@ -51,10 +41,5 @@ describe('audit-policy resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/audit-policy' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/bonds.test.ts
+++ b/packages/api/src/resources/bonds.test.ts
@@ -23,16 +23,6 @@ describe('bonds resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/bonds',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing Bond', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('bonds resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/bonds' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/bucket-users.test.ts
+++ b/packages/api/src/resources/bucket-users.test.ts
@@ -51,16 +51,6 @@ describe('bucket-users resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('viewer cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/bucket-users',
-      headers: { cookie: cookieFor(h.built, viewerSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'bu-c' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/buckets.test.ts
+++ b/packages/api/src/resources/buckets.test.ts
@@ -61,16 +61,6 @@ describe('buckets resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('viewer cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/buckets',
-      headers: { cookie: cookieFor(h.built, viewerSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'bk-c' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/certificates.test.ts
+++ b/packages/api/src/resources/certificates.test.ts
@@ -23,16 +23,6 @@ describe('certificates resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/certificates',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing Certificate', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('certificates resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/certificates' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/cloud-backup-jobs.test.ts
+++ b/packages/api/src/resources/cloud-backup-jobs.test.ts
@@ -23,16 +23,6 @@ describe('cloud-backup-jobs resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/cloud-backup-jobs',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing CloudBackupJob', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('cloud-backup-jobs resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/cloud-backup-jobs' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/cloud-backup-targets.test.ts
+++ b/packages/api/src/resources/cloud-backup-targets.test.ts
@@ -23,16 +23,6 @@ describe('cloud-backup-targets resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/cloud-backup-targets',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing CloudBackupTarget', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('cloud-backup-targets resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/cloud-backup-targets' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/cluster-network.test.ts
+++ b/packages/api/src/resources/cluster-network.test.ts
@@ -34,16 +34,6 @@ describe('cluster-network resource', () => {
     expect([400, 404]).toContain(r.statusCode);
   });
 
-  it('returns 403 for share-only on GET', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/cluster-network',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('does not expose DELETE', async () => {
     const r = await h.built.app.inject({
       method: 'DELETE',
@@ -51,10 +41,5 @@ describe('cluster-network resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/cluster-network' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/config-backup-policy.test.ts
+++ b/packages/api/src/resources/config-backup-policy.test.ts
@@ -34,16 +34,6 @@ describe('config-backup-policy resource', () => {
     expect([400, 404]).toContain(r.statusCode);
   });
 
-  it('returns 403 for share-only on GET', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/config-backup-policy',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('does not expose DELETE', async () => {
     const r = await h.built.app.inject({
       method: 'DELETE',
@@ -51,10 +41,5 @@ describe('config-backup-policy resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/config-backup-policy' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/custom-domains.test.ts
+++ b/packages/api/src/resources/custom-domains.test.ts
@@ -23,16 +23,6 @@ describe('custom-domains resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/custom-domains',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing CustomDomain', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('custom-domains resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/custom-domains' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/data-protection-actions.test.ts
+++ b/packages/api/src/resources/data-protection-actions.test.ts
@@ -89,15 +89,6 @@ describe('data-protection action routes', () => {
     expect(r.statusCode).toBe(200);
   });
 
-  it('viewer gets 403 on renew', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/certificates/letsencrypt/renew',
-      headers: { cookie: cookieFor(h.built, viewerSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing cert', async () => {
     const r = await h.built.app.inject({
       method: 'POST',

--- a/packages/api/src/resources/datasets.test.ts
+++ b/packages/api/src/resources/datasets.test.ts
@@ -65,15 +65,6 @@ describe('datasets resource', () => {
     expect(del.statusCode).toBe(204);
   });
 
-  it('viewer cannot delete (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'DELETE',
-      url: '/api/v1/datasets/ds-a',
-      headers: { cookie: cookieFor(h.built, viewerSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/disks.test.ts
+++ b/packages/api/src/resources/disks.test.ts
@@ -64,16 +64,6 @@ describe('disks resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('user cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/disks',
-      headers: { cookie: cookieFor(h.built, userSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'disk-x' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/encryption-policies.test.ts
+++ b/packages/api/src/resources/encryption-policies.test.ts
@@ -23,16 +23,6 @@ describe('encryption-policies resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/encryption-policies',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing EncryptionPolicy', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('encryption-policies resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/encryption-policies' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/firewall-rules.test.ts
+++ b/packages/api/src/resources/firewall-rules.test.ts
@@ -23,16 +23,6 @@ describe('firewall-rules resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/firewall-rules',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing FirewallRule', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('firewall-rules resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/firewall-rules' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/gpu-actions.test.ts
+++ b/packages/api/src/resources/gpu-actions.test.ts
@@ -14,13 +14,11 @@ function sampleGpu(name: string) {
 describe('gpu-devices action routes', () => {
   let h: TestAppHandle;
   let adminSid: string;
-  let userSid: string;
 
   beforeAll(async () => {
     h = await buildTestApp();
     await h.kube.seed('gpudevices', sampleGpu('gpu0'));
     adminSid = await h.authAs({ username: 'admin', roles: [AuthzRole.Admin] });
-    userSid = await h.authAs({ username: 'alice', roles: [AuthzRole.User] });
   });
   afterAll(async () => h.built.app.close());
 
@@ -41,15 +39,6 @@ describe('gpu-devices action routes', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(200);
-  });
-
-  it('non-admin gets 403 (GpuDevice is admin-only-write)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/gpu-devices/gpu0/unassign',
-      headers: { cookie: cookieFor(h.built, userSid) },
-    });
-    expect(r.statusCode).toBe(403);
   });
 
   it('400 on missing body', async () => {

--- a/packages/api/src/resources/gpu-devices.test.ts
+++ b/packages/api/src/resources/gpu-devices.test.ts
@@ -57,9 +57,4 @@ describe('gpu-devices resource', () => {
     });
     expect(r.statusCode).toBe(405);
   });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/gpu-devices' });
-    expect(r.statusCode).toBe(401);
-  });
 });

--- a/packages/api/src/resources/groups.test.ts
+++ b/packages/api/src/resources/groups.test.ts
@@ -23,16 +23,6 @@ describe('groups resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/groups',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing Group', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('groups resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/groups' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/host-interfaces.test.ts
+++ b/packages/api/src/resources/host-interfaces.test.ts
@@ -23,16 +23,6 @@ describe('host-interfaces resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/host-interfaces',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing HostInterface', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('host-interfaces resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/host-interfaces' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/ingresses.test.ts
+++ b/packages/api/src/resources/ingresses.test.ts
@@ -23,16 +23,6 @@ describe('ingresses resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/ingresses',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing Ingress', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('ingresses resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/ingresses' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/iscsi-targets.test.ts
+++ b/packages/api/src/resources/iscsi-targets.test.ts
@@ -52,16 +52,6 @@ describe('iscsi-targets resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('non-admin cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/iscsi-targets',
-      headers: { cookie: cookieFor(h.built, userSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'iscsi-c' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/iso-libraries.test.ts
+++ b/packages/api/src/resources/iso-libraries.test.ts
@@ -49,16 +49,6 @@ describe('iso-libraries resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('non-admin cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/iso-libraries',
-      headers: { cookie: cookieFor(h.built, userSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'iso-c' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/keycloak-realms.test.ts
+++ b/packages/api/src/resources/keycloak-realms.test.ts
@@ -23,16 +23,6 @@ describe('keycloak-realms resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/keycloak-realms',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing KeycloakRealm', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('keycloak-realms resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/keycloak-realms' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/kms-keys.test.ts
+++ b/packages/api/src/resources/kms-keys.test.ts
@@ -23,16 +23,6 @@ describe('kms-keys resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/kms-keys',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing KmsKey', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('kms-keys resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/kms-keys' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/nfs-servers.test.ts
+++ b/packages/api/src/resources/nfs-servers.test.ts
@@ -49,16 +49,6 @@ describe('nfs-servers resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('non-admin cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/nfs-servers',
-      headers: { cookie: cookieFor(h.built, userSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'nfs-c' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/nvmeof-targets.test.ts
+++ b/packages/api/src/resources/nvmeof-targets.test.ts
@@ -52,16 +52,6 @@ describe('nvmeof-targets resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('non-admin cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/nvmeof-targets',
-      headers: { cookie: cookieFor(h.built, userSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'nvme-c' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/object-stores.test.ts
+++ b/packages/api/src/resources/object-stores.test.ts
@@ -62,16 +62,6 @@ describe('object-stores resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('viewer cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/object-stores',
-      headers: { cookie: cookieFor(h.built, viewerSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'os-c' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/physical-interfaces.test.ts
+++ b/packages/api/src/resources/physical-interfaces.test.ts
@@ -57,9 +57,4 @@ describe('physical-interfaces resource', () => {
     });
     expect(r.statusCode).toBe(405);
   });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/physical-interfaces' });
-    expect(r.statusCode).toBe(401);
-  });
 });

--- a/packages/api/src/resources/pools.test.ts
+++ b/packages/api/src/resources/pools.test.ts
@@ -83,15 +83,6 @@ describe('pools resource', () => {
     expect(r.statusCode).toBe(204);
   });
 
-  it('returns 403 for non-admin writes', async () => {
-    const r = await h.built.app.inject({
-      method: 'DELETE',
-      url: '/api/v1/pools/pool-a',
-      headers: { cookie: cookieFor(h.built, userSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing resources', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/remote-access-tunnels.test.ts
+++ b/packages/api/src/resources/remote-access-tunnels.test.ts
@@ -23,16 +23,6 @@ describe('remote-access-tunnels resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/remote-access-tunnels',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing RemoteAccessTunnel', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('remote-access-tunnels resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/remote-access-tunnels' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/replication-jobs.test.ts
+++ b/packages/api/src/resources/replication-jobs.test.ts
@@ -23,16 +23,6 @@ describe('replication-jobs resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/replication-jobs',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing ReplicationJob', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('replication-jobs resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/replication-jobs' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/replication-targets.test.ts
+++ b/packages/api/src/resources/replication-targets.test.ts
@@ -23,16 +23,6 @@ describe('replication-targets resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/replication-targets',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing ReplicationTarget', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('replication-targets resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/replication-targets' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/scrub-schedules.test.ts
+++ b/packages/api/src/resources/scrub-schedules.test.ts
@@ -23,16 +23,6 @@ describe('scrub-schedules resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/scrub-schedules',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing ScrubSchedule', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('scrub-schedules resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/scrub-schedules' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/service-policy.test.ts
+++ b/packages/api/src/resources/service-policy.test.ts
@@ -34,16 +34,6 @@ describe('service-policy resource', () => {
     expect([400, 404]).toContain(r.statusCode);
   });
 
-  it('returns 403 for share-only on GET', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/service-policy',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('does not expose DELETE', async () => {
     const r = await h.built.app.inject({
       method: 'DELETE',
@@ -51,10 +41,5 @@ describe('service-policy resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/service-policy' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/shares.test.ts
+++ b/packages/api/src/resources/shares.test.ts
@@ -65,15 +65,6 @@ describe('shares resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('viewer cannot delete (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'DELETE',
-      url: '/api/v1/shares/share-a',
-      headers: { cookie: cookieFor(h.built, viewerSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/slos.test.ts
+++ b/packages/api/src/resources/slos.test.ts
@@ -23,16 +23,6 @@ describe('slos resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/slos',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing ServiceLevelObjective', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('slos resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/slos' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/smart-policies.test.ts
+++ b/packages/api/src/resources/smart-policies.test.ts
@@ -23,16 +23,6 @@ describe('smart-policies resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/smart-policies',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing SmartPolicy', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('smart-policies resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/smart-policies' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/smb-servers.test.ts
+++ b/packages/api/src/resources/smb-servers.test.ts
@@ -49,16 +49,6 @@ describe('smb-servers resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('non-admin cannot write (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/smb-servers',
-      headers: { cookie: cookieFor(h.built, userSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'smb-c' } },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 on missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/snapshot-schedules.test.ts
+++ b/packages/api/src/resources/snapshot-schedules.test.ts
@@ -23,16 +23,6 @@ describe('snapshot-schedules resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/snapshot-schedules',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing SnapshotSchedule', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('snapshot-schedules resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/snapshot-schedules' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/snapshots.test.ts
+++ b/packages/api/src/resources/snapshots.test.ts
@@ -61,15 +61,6 @@ describe('snapshots resource', () => {
     expect(d.statusCode).toBe(204);
   });
 
-  it('viewer cannot delete (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'DELETE',
-      url: '/api/v1/snapshots/snap-a',
-      headers: { cookie: cookieFor(h.built, viewerSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('404 missing', async () => {
     const r = await h.built.app.inject({
       method: 'GET',

--- a/packages/api/src/resources/ssh-keys.test.ts
+++ b/packages/api/src/resources/ssh-keys.test.ts
@@ -23,16 +23,6 @@ describe('ssh-keys resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/ssh-keys',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing SshKey', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('ssh-keys resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/ssh-keys' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/system-settings.test.ts
+++ b/packages/api/src/resources/system-settings.test.ts
@@ -34,16 +34,6 @@ describe('system-settings resource', () => {
     expect([400, 404]).toContain(r.statusCode);
   });
 
-  it('returns 403 for share-only on GET', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/system/settings',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('does not expose DELETE', async () => {
     const r = await h.built.app.inject({
       method: 'DELETE',
@@ -51,10 +41,5 @@ describe('system-settings resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/system/settings' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/traffic-policies.test.ts
+++ b/packages/api/src/resources/traffic-policies.test.ts
@@ -23,16 +23,6 @@ describe('traffic-policies resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/traffic-policies',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing TrafficPolicy', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('traffic-policies resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/traffic-policies' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/update-policy.test.ts
+++ b/packages/api/src/resources/update-policy.test.ts
@@ -34,16 +34,6 @@ describe('update-policy resource', () => {
     expect([400, 404]).toContain(r.statusCode);
   });
 
-  it('returns 403 for share-only on GET', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/update-policy',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('does not expose DELETE', async () => {
     const r = await h.built.app.inject({
       method: 'DELETE',
@@ -51,10 +41,5 @@ describe('update-policy resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/update-policy' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/ups-policy.test.ts
+++ b/packages/api/src/resources/ups-policy.test.ts
@@ -34,16 +34,6 @@ describe('ups-policy resource', () => {
     expect([400, 404]).toContain(r.statusCode);
   });
 
-  it('returns 403 for share-only on GET', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/ups-policy',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('does not expose DELETE', async () => {
     const r = await h.built.app.inject({
       method: 'DELETE',
@@ -51,10 +41,5 @@ describe('ups-policy resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/ups-policy' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/users-actions.test.ts
+++ b/packages/api/src/resources/users-actions.test.ts
@@ -6,13 +6,11 @@ describe('user action routes (reset-password, enroll-2fa)', () => {
   let h: TestAppHandle;
   let adminSid: string;
   let aliceSid: string;
-  let viewerSid: string;
 
   beforeAll(async () => {
     h = await buildTestApp();
     adminSid = await h.authAs({ username: 'admin', roles: [AuthzRole.Admin] });
     aliceSid = await h.authAs({ username: 'alice', roles: [AuthzRole.User] });
-    viewerSid = await h.authAs({ username: 'obs', roles: [AuthzRole.Viewer] });
   });
   afterAll(async () => h.built.app.close());
 
@@ -27,15 +25,6 @@ describe('user action routes (reset-password, enroll-2fa)', () => {
     expect(body.accepted).toBe(true);
   });
 
-  it('non-admin cannot reset-password for others (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/users/bob/reset-password',
-      headers: { cookie: cookieFor(h.built, aliceSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('user can enroll themselves in 2FA', async () => {
     const r = await h.built.app.inject({
       method: 'POST',
@@ -46,14 +35,5 @@ describe('user action routes (reset-password, enroll-2fa)', () => {
     const body = r.json() as { secret: string; otpauthUrl: string };
     expect(body.secret).toMatch(/^[A-Z2-7]+$/);
     expect(body.otpauthUrl).toContain('otpauth://totp/');
-  });
-
-  it('viewer cannot enroll someone else in 2FA', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/users/alice/enroll-2fa',
-      headers: { cookie: cookieFor(h.built, viewerSid) },
-    });
-    expect(r.statusCode).toBe(403);
   });
 });

--- a/packages/api/src/resources/users.test.ts
+++ b/packages/api/src/resources/users.test.ts
@@ -12,13 +12,11 @@ const sample = {
 describe('users resource', () => {
   let h: TestAppHandle;
   let adminSid: string;
-  let userSid: string;
 
   beforeAll(async () => {
     h = await buildTestApp();
     await h.kube.seed('users', sample);
     adminSid = await h.authAs({ username: 'admin', roles: [AuthzRole.Admin] });
-    userSid = await h.authAs({ username: 'bob', roles: [AuthzRole.User] });
   });
   afterAll(async () => h.built.app.close());
 
@@ -59,16 +57,6 @@ describe('users resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(d.statusCode).toBe(204);
-  });
-
-  it('non-admin cannot create users (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/users',
-      headers: { cookie: cookieFor(h.built, userSid), 'content-type': 'application/json' },
-      payload: { ...sample, metadata: { name: 'malicious' }, spec: { username: 'mal' } },
-    });
-    expect(r.statusCode).toBe(403);
   });
 
   it('404 missing', async () => {

--- a/packages/api/src/resources/vip-pools.test.ts
+++ b/packages/api/src/resources/vip-pools.test.ts
@@ -23,16 +23,6 @@ describe('vip-pools resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/vip-pools',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing VipPool', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('vip-pools resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/vip-pools' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/vlans.test.ts
+++ b/packages/api/src/resources/vlans.test.ts
@@ -23,16 +23,6 @@ describe('vlans resource', () => {
     expect(Array.isArray(body.items)).toBe(true);
   });
 
-  it('returns 403 for share-only on list', async () => {
-    const shareSid = await h.authAs({ username: 'guest', roles: ['novanas:share-only'] });
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/vlans',
-      headers: { cookie: cookieFor(h.built, shareSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
   it('returns 404 for missing Vlan', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
@@ -40,10 +30,5 @@ describe('vlans resource', () => {
       headers: { cookie: cookieFor(h.built, adminSid) },
     });
     expect(r.statusCode).toBe(404);
-  });
-
-  it('requires authentication', async () => {
-    const r = await h.built.app.inject({ method: 'GET', url: '/api/v1/vlans' });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/resources/vms-actions.test.ts
+++ b/packages/api/src/resources/vms-actions.test.ts
@@ -14,13 +14,11 @@ function sampleVm(user: string, name: string) {
 describe('vms action routes (E1-API-Actions)', () => {
   let h: TestAppHandle;
   let aliceSid: string;
-  let viewerSid: string;
 
   beforeAll(async () => {
     h = await buildTestApp();
     await h.kube.seed('vms', sampleVm('alice', 'vm1'), 'user-alice');
     aliceSid = await h.authAs({ username: 'alice', roles: [AuthzRole.User] });
-    viewerSid = await h.authAs({ username: 'obs', roles: [AuthzRole.Viewer] });
   });
   afterAll(async () => h.built.app.close());
 
@@ -44,15 +42,6 @@ describe('vms action routes (E1-API-Actions)', () => {
       headers: { cookie: cookieFor(h.built, aliceSid) },
     });
     expect(r.statusCode).toBe(200);
-  });
-
-  it('viewer gets 403', async () => {
-    const r = await h.built.app.inject({
-      method: 'POST',
-      url: '/api/v1/vms/user-alice/vm1/start',
-      headers: { cookie: cookieFor(h.built, viewerSid) },
-    });
-    expect(r.statusCode).toBe(403);
   });
 
   it('404 for missing VM', async () => {

--- a/packages/api/src/resources/vms.test.ts
+++ b/packages/api/src/resources/vms.test.ts
@@ -18,13 +18,13 @@ function sampleFor(user: string, name: string) {
 describe('vms resource (namespaced)', () => {
   let h: TestAppHandle;
   let aliceSid: string;
-  let shareOnlySid: string;
 
   beforeAll(async () => {
     h = await buildTestApp();
-    await h.kube.seed('vms', sampleFor('alice', 'vm-a'), 'user-alice');
+    // With auth disabled, every request resolves to the synthetic admin user,
+    // so namespace scoping always uses `user-admin`.
+    await h.kube.seed('vms', sampleFor('admin', 'vm-a'), 'user-admin');
     aliceSid = await h.authAs({ username: 'alice', roles: [AuthzRole.User] });
-    shareOnlySid = await h.authAs({ username: 'bob', roles: [AuthzRole.ShareOnly] });
   });
   afterAll(async () => h.built.app.close());
 
@@ -66,15 +66,6 @@ describe('vms resource (namespaced)', () => {
       headers: { cookie: cookieFor(h.built, aliceSid) },
     });
     expect(d.statusCode).toBe(204);
-  });
-
-  it('share-only role cannot read (403)', async () => {
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/vms',
-      headers: { cookie: cookieFor(h.built, shareOnlySid) },
-    });
-    expect(r.statusCode).toBe(403);
   });
 
   it('404 missing', async () => {

--- a/packages/api/src/routes/auth-device-code.test.ts
+++ b/packages/api/src/routes/auth-device-code.test.ts
@@ -31,7 +31,7 @@ describe('auth device-code + token endpoints (CLI flow)', () => {
     expect([200, 502]).toContain(r.statusCode);
   });
 
-  it('GET /auth/me returns session user', async () => {
+  it('GET /auth/me returns synthetic admin (auth disabled)', async () => {
     const r = await h.built.app.inject({
       method: 'GET',
       url: '/api/v1/auth/me',
@@ -39,14 +39,6 @@ describe('auth device-code + token endpoints (CLI flow)', () => {
     });
     expect(r.statusCode).toBe(200);
     const body = r.json() as { username: string };
-    expect(body.username).toBe('alice');
-  });
-
-  it('GET /auth/me returns 401 without session', async () => {
-    const r = await h.built.app.inject({
-      method: 'GET',
-      url: '/api/v1/auth/me',
-    });
-    expect(r.statusCode).toBe(401);
+    expect(body.username).toBe('admin');
   });
 });

--- a/packages/api/src/routes/composite.test.ts
+++ b/packages/api/src/routes/composite.test.ts
@@ -92,15 +92,6 @@ describe('composite routes', () => {
       });
       expect(r.statusCode).toBe(400);
     });
-
-    it('requires auth', async () => {
-      const r = await h.built.app.inject({
-        method: 'POST',
-        url: '/api/v1/composite/dataset-with-share',
-        payload: { dataset, shares: [shareBody('x')] },
-      });
-      expect(r.statusCode).toBe(401);
-    });
   });
 
   // --------------------------------------------------------------------------

--- a/packages/api/src/routes/system-actions.test.ts
+++ b/packages/api/src/routes/system-actions.test.ts
@@ -83,7 +83,6 @@ function fakeDb(): { db: DbClient; rows: Job[] } {
 describe('system action routes (E1-API-Actions)', () => {
   let built: BuiltApp;
   let adminSid: string;
-  let viewerSid: string;
   const fake = fakeDb();
 
   beforeAll(async () => {
@@ -105,19 +104,6 @@ describe('system action routes (E1-API-Actions)', () => {
       idToken: 't',
       accessToken: 't',
       claims: { sub: 'a', preferred_username: 'admin', realm_access: { roles: [AuthzRole.Admin] } },
-    });
-    viewerSid = await built.sessions.create({
-      userId: 'v',
-      username: 'obs',
-      createdAt: Date.now(),
-      expiresAt: Date.now() + 3600_000,
-      idToken: 't',
-      accessToken: 't',
-      claims: {
-        sub: 'v',
-        preferred_username: 'obs',
-        realm_access: { roles: [AuthzRole.Viewer] },
-      },
     });
   });
   afterAll(async () => built.app.close());
@@ -163,22 +149,5 @@ describe('system action routes (E1-API-Actions)', () => {
       headers: { cookie: cookieFor(built, adminSid) },
     });
     expect(r.statusCode).toBe(200);
-  });
-
-  it('viewer gets 403 on system/reset', async () => {
-    const r = await built.app.inject({
-      method: 'POST',
-      url: '/api/v1/system/reset',
-      headers: { cookie: cookieFor(built, viewerSid) },
-    });
-    expect(r.statusCode).toBe(403);
-  });
-
-  it('unauthenticated gets 401', async () => {
-    const r = await built.app.inject({
-      method: 'POST',
-      url: '/api/v1/system/reset',
-    });
-    expect(r.statusCode).toBe(401);
   });
 });

--- a/packages/api/src/routes/system.test.ts
+++ b/packages/api/src/routes/system.test.ts
@@ -65,11 +65,6 @@ describe('system info/network/alerts/events routes', () => {
     expect(Array.isArray(body.loadAvg)).toBe(true);
   });
 
-  it('GET /system/info requires auth', async () => {
-    const r = await built.app.inject({ method: 'GET', url: '/api/v1/system/info' });
-    expect(r.statusCode).toBe(401);
-  });
-
   it('GET /system/network returns interface list', async () => {
     const r = await built.app.inject({
       method: 'GET',
@@ -145,10 +140,5 @@ describe('CRD routes fallback when kubeCustom is missing', () => {
     expect(typeof body.message).toBe('string');
     // Ensure the old stub envelope is gone.
     expect(body).not.toHaveProperty('wave');
-  });
-
-  it('GET /api/v1/pools still enforces auth', async () => {
-    const r = await built.app.inject({ method: 'GET', url: '/api/v1/pools' });
-    expect(r.statusCode).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary

- Strips session/Bearer/API-token authentication and role-based authz from the API server so we can iterate on storage and CRD-replacement work without Keycloak being in the loop.
- The auth plugin now injects a synthetic admin user (\`username: 'admin'\`, roles \`['admin','user']\`, \`claims.auth_disabled = true\`) on every request.
- \`requireAuth\` / \`requireRole\` are no-op preHandlers; \`hasRole\`, \`canRead\`, \`canWrite\`, \`canDelete\`, \`canAction\` always return \`true\`.
- 401/403 test assertions removed; \`apps\`/\`vms\` namespace-scoped tests re-seeded into \`user-admin\` so listing tests stay meaningful.

Re-enabling is tracked in #71 (no env flag — explicit code change so we don't accidentally ship a production binary with a bypass).

## Test plan

- [x] \`pnpm -r typecheck\` clean
- [x] \`pnpm -r lint\` clean (biome)
- [x] \`pnpm --filter @novanas/api test\` — 80 files / 265 tests pass
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)