### PR TITLE
feat(meta): novanas-meta daemon end-to-end (architecture-v2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +461,12 @@ checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -524,6 +554,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "env_filter"
@@ -704,8 +746,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -715,9 +759,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -759,6 +805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +842,20 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -871,6 +940,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1192,6 +1277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1401,35 @@ dependencies = [
  "tonic-build",
  "tracing",
  "tracing-opentelemetry",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "novanas-meta"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "futures",
+ "hyper-util",
+ "postcard",
+ "prost",
+ "prost-types",
+ "redb",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tower",
+ "tracing",
  "tracing-subscriber",
  "uuid",
 ]
@@ -1517,6 +1637,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1720,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -1708,6 +1851,61 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1905,16 +2103,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1922,6 +2125,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2033,6 +2237,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2160,6 +2365,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2410,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -2368,7 +2592,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -2857,6 +3083,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "storage/dataplane/ndp",
     "storage/dataplane/nvmeof-tcp",
     "storage/dataplane/nbd",
+    "storage/meta",
 ]
 resolver = "2"
 

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,12 +1,7 @@
-# Binaries
-bin/
-/controller
-/csi
-/filer
-/s3gw
-/agent
-/meta
-/novanasctl
+# Stray Go-era build outputs (binaries that the deleted Go cmd/ tree
+# used to produce). The Rust storage/meta crate lives at the same
+# path, so be careful not to ignore the directory; only ignore the
+# bare-name binaries we know about by name.
 *.exe
 *.exe~
 *.dll

--- a/storage/api/proto/meta/meta.proto
+++ b/storage/api/proto/meta/meta.proto
@@ -1,287 +1,196 @@
-// MetaService — the cluster brain's gRPC contract.
+// Copyright NovaNas contributors. SPDX-License-Identifier: Apache-2.0
 //
-// Called by:
-//   - novanas-frontend  (chunk-map lookups, volume create/delete)
-//   - novanas-data      (heartbeat, ClaimDisk, task polling)
-//   - novanas-api       (state mutation events: pool / disk / volume)
+// Wire contract for the novanas-meta daemon (architecture-v2, single-host).
 //
-// Single-host design: there is only one MetaService instance per appliance.
-// Wire format: tonic + prost. Listening on a Unix-domain socket by default
-// (/var/run/novanas/meta.sock).
+// The meta daemon is the cold-path source of placement and lifecycle truth
+// for the local data daemon. It subscribes to novanas-api as the SoT of
+// pools/disks/volumes, runs CRUSH, persists chunk maps, and emits tasks for
+// the data daemon to claim.
 
 syntax = "proto3";
 
 package novanas.meta.v1;
 
-import "google/protobuf/empty.proto";
-import "google/protobuf/timestamp.proto";
-
-// =============================================================================
-// Service
-// =============================================================================
-
-service MetaService {
-  // ----- Pool registry --------------------------------------------------------
-  rpc PutPool(Pool) returns (google.protobuf.Empty);
-  rpc GetPool(PoolRef) returns (Pool);
-  rpc ListPools(google.protobuf.Empty) returns (PoolList);
-  rpc DeletePool(PoolRef) returns (google.protobuf.Empty);
-
-  // ----- Disk registry --------------------------------------------------------
-  rpc PutDisk(Disk) returns (google.protobuf.Empty);
-  rpc GetDisk(DiskRef) returns (Disk);
-  rpc ListDisks(ListDisksRequest) returns (DiskList);
-  rpc DeleteDisk(DiskRef) returns (google.protobuf.Empty);
-
-  // ----- Volume lifecycle (block) --------------------------------------------
-  // CreateVolume runs CRUSH against the named pool's claimed disks and
-  // persists a chunk map. It returns the created volume with its full
-  // chunk map populated. Idempotent: re-create with the same name and
-  // identical spec is a no-op.
-  rpc CreateVolume(CreateVolumeRequest) returns (Volume);
-  rpc GetVolume(VolumeRef) returns (Volume);
-  rpc ListVolumes(google.protobuf.Empty) returns (VolumeList);
-  rpc DeleteVolume(VolumeRef) returns (google.protobuf.Empty);
-
-  // GetChunkMap returns the chunk map slice covering [chunk_index_lo,
-  // chunk_index_hi). Used by the frontend's volume bdev to translate
-  // volume-offset reads/writes into chunk identifiers.
-  rpc GetChunkMap(GetChunkMapRequest) returns (ChunkMapSlice);
-
-  // ----- Disk claim flow ------------------------------------------------------
-  // ClaimDisk asks meta to record that disk D should be a member of
-  // pool P with role R. Meta persists, picks a chunk_store_id, and
-  // returns. The data daemon polls TaskQueue and gets a ClaimDiskTask
-  // with the full claim details. Idempotent.
-  rpc ClaimDisk(ClaimDiskRequest) returns (Disk);
-  rpc ReleaseDisk(DiskRef) returns (google.protobuf.Empty);
-
-  // ----- Tasks (meta → data work queue) --------------------------------------
-  // PollTasks blocks for up to deadline_ms returning any pending task
-  // for the calling node. The data daemon long-polls this. AckTask
-  // marks a task complete and durably removes it from the queue.
-  rpc PollTasks(PollTasksRequest) returns (TaskBatch);
-  rpc AckTask(AckTaskRequest) returns (google.protobuf.Empty);
-
-  // ----- Health / liveness ---------------------------------------------------
-  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
-}
-
-// =============================================================================
-// Common types
-// =============================================================================
-
-// PoolRef and friends are name-keyed handles. UUIDs live inside the
-// records but the canonical key for RPCs is the human-readable name.
-message PoolRef { string name = 1; }
-message DiskRef { string wwn = 1; }
-message VolumeRef { string name = 1; }
-
-enum DeviceClass {
-  DEVICE_CLASS_UNKNOWN = 0;
-  DEVICE_CLASS_HDD = 1;
-  DEVICE_CLASS_SSD = 2;
-  DEVICE_CLASS_NVME = 3;
-}
-
-enum DiskRole {
-  DISK_ROLE_UNSET = 0;
-  DISK_ROLE_DATA = 1;
-  DISK_ROLE_METADATA = 2;
-  DISK_ROLE_BOTH = 3;
-}
-
-// =============================================================================
-// Pool
-// =============================================================================
+// ---------------------------------------------------------------------------
+// Core resources
+// ---------------------------------------------------------------------------
 
 message Pool {
-  string name = 1;
-  string uuid = 2;                // generated on first PutPool
-  string tier = 3;                // free-form label ("hot", "warm", "cold")
-  DeviceClass preferred_class = 4;
-  google.protobuf.Timestamp created_at = 5;
+  string uuid = 1;
+  string name = 2;
+  uint32 replication_factor = 3;  // default 2
+  string tier = 4;                // "fast" | "bulk" | "" (any)
+  uint64 generation = 5;
 }
-
-message PoolList { repeated Pool items = 1; }
-
-// =============================================================================
-// Disk
-// =============================================================================
 
 message Disk {
-  string wwn = 1;                 // canonical id (e.g. "naa.50014ee2bb0fe22f")
-  string uuid = 2;                // persistent UUID derived from WWN
-  string slot = 3;                // /dev/sda or nvme0n1 — informational only
-  string model = 4;
-  uint64 size_bytes = 5;
-  DeviceClass class = 6;
-
-  // Pool membership; empty when the disk is unclaimed.
-  string pool_name = 7;
-  DiskRole role = 8;
-
-  // Live state reported by data daemons in heartbeats.
-  bool present = 9;               // physically attached?
-  bool superblock_valid = 10;     // last superblock read CRC-OK?
-  google.protobuf.Timestamp last_seen = 11;
+  string uuid = 1;
+  string node = 2;          // single-host: always the local node
+  string device_path = 3;   // e.g. /dev/nvme0n1
+  uint64 size_bytes = 4;
+  string pool_uuid = 5;     // empty = unclaimed
+  string state = 6;         // "unclaimed" | "claiming" | "ready" | "failed"
+  string tier = 7;          // matches Pool.tier when claimed
+  bool present = 8;         // device currently visible
+  uint64 generation = 9;
 }
-
-message ListDisksRequest {
-  string pool_name = 1;           // empty = all disks
-}
-
-message DiskList { repeated Disk items = 1; }
-
-// =============================================================================
-// Volume + chunk map
-// =============================================================================
 
 message ProtectionSpec {
-  // mode = "replication" → factor copies per chunk
-  // mode = "erasure"     → erasure_data + erasure_parity shards per chunk
-  string mode = 1;
-  uint32 replication_factor = 2;
-  uint32 erasure_data = 3;
-  uint32 erasure_parity = 4;
-}
-
-message CreateVolumeRequest {
-  string name = 1;
-  string pool_name = 2;
-  uint64 size_bytes = 3;
-  ProtectionSpec protection = 4;
+  uint32 replication_factor = 1;
 }
 
 message Volume {
-  string name = 1;
-  string uuid = 2;
-  string pool_name = 3;
+  string uuid = 1;
+  string name = 2;
+  string pool_uuid = 3;
   uint64 size_bytes = 4;
-  uint32 chunk_size_bytes = 5;
-  uint64 chunk_count = 6;          // ceil(size_bytes / chunk_size_bytes)
-  ProtectionSpec protection = 7;
-  string phase = 8;                // "Pending" | "Ready" | "Failed"
-  google.protobuf.Timestamp created_at = 9;
+  ProtectionSpec protection = 5;
+  uint64 chunk_size_bytes = 6;   // server-set, currently 4 MiB
+  uint64 chunk_count = 7;
+  uint64 generation = 8;
 }
 
-message VolumeList { repeated Volume items = 1; }
-
-// One chunk's placement: chunk_id is content-addressable on first write,
-// so it's empty for unallocated/un-written chunks. Locations names the
-// disks that hold (or will hold) a copy.
-message ChunkMapEntry {
-  uint64 chunk_index = 1;
-  string chunk_id = 2;
-  repeated string disk_wwns = 3;   // size = repl factor / shard count
+message ChunkPlacement {
+  uint32 index = 1;
+  string chunk_id = 2;          // empty until first write (content-addressed)
+  repeated string disk_uuids = 3;
 }
 
-message GetChunkMapRequest {
-  string volume_name = 1;
-  uint64 chunk_index_lo = 2;
-  uint64 chunk_index_hi = 3;       // exclusive
+message ChunkMap {
+  string volume_uuid = 1;
+  repeated ChunkPlacement chunks = 2;
 }
 
-message ChunkMapSlice {
-  repeated ChunkMapEntry entries = 1;
-}
-
-// =============================================================================
-// Disk claim
-// =============================================================================
-
-message ClaimDiskRequest {
-  string wwn = 1;
-  string pool_name = 2;
-  DiskRole role = 3;
-  bool force = 4;                  // overwrite an existing superblock
-}
-
-// =============================================================================
-// Tasks (work queue meta → data)
-// =============================================================================
+// ---------------------------------------------------------------------------
+// Tasks
+// ---------------------------------------------------------------------------
 
 enum TaskKind {
-  TASK_KIND_UNSPECIFIED = 0;
-  TASK_KIND_CLAIM_DISK = 1;        // write superblock, attach bdev, register chunk store
-  TASK_KIND_RELEASE_DISK = 2;      // detach, zero superblock, release bdev
-  TASK_KIND_REPLICATE_CHUNK = 3;   // copy chunk from src disk to dst disk
-  TASK_KIND_MIGRATE_CHUNK = 4;     // copy chunk from src pool to dst pool, then release src
-  TASK_KIND_SCRUB_CHUNK = 5;       // verify chunk checksum, surface errors
-  TASK_KIND_DELETE_CHUNK = 6;      // free chunk on the named disk
+  TASK_UNKNOWN = 0;
+  TASK_CLAIM_DISK = 1;
+  TASK_RELEASE_DISK = 2;
+  TASK_REPLICATE_CHUNK = 3;
+  TASK_TIER_MIGRATE_CHUNK = 4;  // future hook; never emitted in this PR
 }
 
 message ClaimDiskTask {
-  string pool_uuid = 1;
-  string pool_name = 2;
-  string disk_uuid = 3;
-  DiskRole role = 4;
-  bytes crush_digest = 5;          // 32 bytes sha256 — written into superblock
-  bool force = 6;
+  string disk_uuid = 1;
+  string pool_uuid = 2;
 }
 
-message ReleaseDiskTask { string disk_uuid = 1; }
+message ReleaseDiskTask {
+  string disk_uuid = 1;
+}
 
 message ChunkOpTask {
-  string chunk_id = 1;
-  string volume_uuid = 2;
-  uint64 chunk_index = 3;
-  string src_disk_uuid = 4;
-  repeated string dst_disk_uuids = 5;
+  string volume_uuid = 1;
+  uint32 chunk_index = 2;
+  repeated string source_disk_uuids = 3;
+  repeated string target_disk_uuids = 4;
 }
 
 message Task {
   string id = 1;
   TaskKind kind = 2;
-  string node_id = 3;              // which data daemon should pick this up
-  google.protobuf.Timestamp created_at = 4;
-  uint32 attempt = 5;
-
-  // Exactly one of:
-  ClaimDiskTask claim_disk = 10;
-  ReleaseDiskTask release_disk = 11;
-  ChunkOpTask chunk_op = 12;
+  uint64 created_unix_secs = 3;
+  oneof payload {
+    ClaimDiskTask claim_disk = 10;
+    ReleaseDiskTask release_disk = 11;
+    ChunkOpTask chunk_op = 12;
+  }
 }
 
-message PollTasksRequest {
-  string node_id = 1;
-  uint32 max_tasks = 2;            // batch size cap
-  uint32 deadline_ms = 3;          // long-poll deadline
+// ---------------------------------------------------------------------------
+// RPC messages
+// ---------------------------------------------------------------------------
+
+message PutPoolRequest { Pool pool = 1; }
+message PutPoolResponse { Pool pool = 1; }
+
+message GetPoolRequest { string uuid = 1; }
+message GetPoolResponse { Pool pool = 1; }
+
+message ListPoolsRequest {}
+message ListPoolsResponse { repeated Pool pools = 1; }
+
+message DeletePoolRequest { string uuid = 1; }
+message DeletePoolResponse {}
+
+message PutDiskRequest { Disk disk = 1; }
+message PutDiskResponse { Disk disk = 1; }
+
+message GetDiskRequest { string uuid = 1; }
+message GetDiskResponse { Disk disk = 1; }
+
+message ListDisksRequest { string pool_uuid = 1; }  // empty = all
+message ListDisksResponse { repeated Disk disks = 1; }
+
+message DeleteDiskRequest { string uuid = 1; }
+message DeleteDiskResponse {}
+
+message CreateVolumeRequest {
+  string uuid = 1;
+  string name = 2;
+  string pool_uuid = 3;
+  uint64 size_bytes = 4;
+  ProtectionSpec protection = 5;
 }
+message CreateVolumeResponse { Volume volume = 1; ChunkMap chunk_map = 2; }
 
-message TaskBatch { repeated Task items = 1; }
+message GetVolumeRequest { string uuid = 1; }
+message GetVolumeResponse { Volume volume = 1; }
 
-message AckTaskRequest {
-  string task_id = 1;
-  bool success = 2;
-  string error_message = 3;        // populated when success = false
-}
+message ListVolumesRequest { string pool_uuid = 1; }  // empty = all
+message ListVolumesResponse { repeated Volume volumes = 1; }
 
-// =============================================================================
-// Heartbeat
-// =============================================================================
+message DeleteVolumeRequest { string uuid = 1; }
+message DeleteVolumeResponse {}
 
-enum DaemonKind {
-  DAEMON_KIND_UNSPECIFIED = 0;
-  DAEMON_KIND_DATA = 1;
-  DAEMON_KIND_FRONTEND = 2;
-}
+message GetChunkMapRequest { string volume_uuid = 1; }
+message GetChunkMapResponse { ChunkMap chunk_map = 1; }
 
-message HeartbeatRequest {
-  string node_id = 1;
-  DaemonKind kind = 2;
-  string version = 3;
-  // Data daemons enclose live disk presence info so meta can update its
-  // registry. The Disk records here are STATUS only — name, present,
-  // superblock_valid, last_seen — meta keeps the spec fields it owns.
-  repeated Disk disks = 4;
-}
+message ClaimDiskRequest { string disk_uuid = 1; string pool_uuid = 2; }
+message ClaimDiskResponse { Disk disk = 1; }
 
-message HeartbeatResponse {
-  // CRUSH digest meta would like to see in the next superblock write,
-  // when it differs from the disk's current value.
-  bytes desired_crush_digest = 1;
-  // Tasks are returned via PollTasks; this is just a hint that some are
-  // queued so the daemon should poll soon.
-  uint32 pending_task_count = 2;
+message ReleaseDiskRequest { string disk_uuid = 1; }
+message ReleaseDiskResponse { Disk disk = 1; }
+
+message PollTasksRequest { uint32 max = 1; }
+message PollTasksResponse { repeated Task tasks = 1; }
+
+message AckTaskRequest { string task_id = 1; bool success = 2; string error = 3; }
+message AckTaskResponse {}
+
+message HeartbeatRequest { string client_id = 1; }
+message HeartbeatResponse { uint64 server_unix_secs = 1; }
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+service MetaService {
+  rpc PutPool(PutPoolRequest) returns (PutPoolResponse);
+  rpc GetPool(GetPoolRequest) returns (GetPoolResponse);
+  rpc ListPools(ListPoolsRequest) returns (ListPoolsResponse);
+  rpc DeletePool(DeletePoolRequest) returns (DeletePoolResponse);
+
+  rpc PutDisk(PutDiskRequest) returns (PutDiskResponse);
+  rpc GetDisk(GetDiskRequest) returns (GetDiskResponse);
+  rpc ListDisks(ListDisksRequest) returns (ListDisksResponse);
+  rpc DeleteDisk(DeleteDiskRequest) returns (DeleteDiskResponse);
+
+  rpc CreateVolume(CreateVolumeRequest) returns (CreateVolumeResponse);
+  rpc GetVolume(GetVolumeRequest) returns (GetVolumeResponse);
+  rpc ListVolumes(ListVolumesRequest) returns (ListVolumesResponse);
+  rpc DeleteVolume(DeleteVolumeRequest) returns (DeleteVolumeResponse);
+
+  rpc GetChunkMap(GetChunkMapRequest) returns (GetChunkMapResponse);
+
+  rpc ClaimDisk(ClaimDiskRequest) returns (ClaimDiskResponse);
+  rpc ReleaseDisk(ReleaseDiskRequest) returns (ReleaseDiskResponse);
+
+  rpc PollTasks(PollTasksRequest) returns (PollTasksResponse);
+  rpc AckTask(AckTaskRequest) returns (AckTaskResponse);
+
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
 }

--- a/storage/meta/Cargo.toml
+++ b/storage/meta/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "novanas-meta"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "novanas-meta: cold-path metadata daemon (architecture-v2)"
+
+[[bin]]
+name = "novanas-meta"
+path = "src/main.rs"
+
+[lib]
+name = "novanas_meta"
+path = "src/lib.rs"
+
+[dependencies]
+tonic = "0.13"
+prost = "0.13"
+prost-types = "0.13"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+redb = "3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+ring = "0.17"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"
+thiserror = "1"
+postcard = { version = "1", features = ["alloc"] }
+uuid = { version = "1", features = ["v4"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+tower = "0.5"
+async-trait = "0.1"
+futures = "0.3"
+
+[build-dependencies]
+tonic-build = "0.13"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["full", "test-util", "macros"] }

--- a/storage/meta/build.rs
+++ b/storage/meta/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .compile_protos(&["../api/proto/meta/meta.proto"], &["../api/proto"])?;
+    Ok(())
+}

--- a/storage/meta/src/api_client.rs
+++ b/storage/meta/src/api_client.rs
@@ -1,0 +1,371 @@
+//! HTTP poller against `novanas-api`.
+//!
+//! On each tick:
+//! 1. Fetch `/api/v1/pools`, `/api/v1/disks`, `/api/v1/block-volumes`.
+//! 2. Reconcile into the local redb store: PutPool / PutDisk / CreateVolume.
+//! 3. When `Disk.spec.pool` changes (or a previously-unclaimed disk moves into
+//!    a pool), enqueue a `ClaimDiskTask`.
+//! 4. When a new BlockVolume appears, run CRUSH and persist the chunk map.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+
+use crate::crush;
+use crate::server::pool_topology;
+use crate::store::Store;
+use crate::types::{ChunkPlacement, Disk, Pool, ProtectionSpec, Task, TaskPayload, Volume};
+use crate::CHUNK_SIZE_BYTES;
+
+#[derive(Debug, Clone)]
+pub struct ApiSubscriberConfig {
+    pub base_url: String,
+    pub poll_interval: Duration,
+    pub node_name: String,
+}
+
+impl Default for ApiSubscriberConfig {
+    fn default() -> Self {
+        Self {
+            base_url: "http://localhost:3000".to_string(),
+            poll_interval: Duration::from_secs(5),
+            node_name: "local".to_string(),
+        }
+    }
+}
+
+// --- API DTOs (loose: only fields we care about) -------------------------
+
+#[derive(Debug, Deserialize, Default)]
+struct ApiPool {
+    #[serde(default)]
+    uuid: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default, alias = "replicationFactor", alias = "replication_factor")]
+    replication_factor: Option<u32>,
+    #[serde(default)]
+    tier: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ApiDisk {
+    #[serde(default)]
+    uuid: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    name: String,
+    #[serde(default)]
+    node: Option<String>,
+    #[serde(default, alias = "devicePath", alias = "device_path")]
+    device_path: Option<String>,
+    #[serde(default, alias = "sizeBytes", alias = "size_bytes")]
+    size_bytes: Option<u64>,
+    #[serde(default, alias = "poolUuid", alias = "pool", alias = "pool_uuid")]
+    pool_uuid: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    tier: Option<String>,
+    #[serde(default)]
+    present: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ApiProtection {
+    #[serde(default, alias = "replicationFactor", alias = "replication_factor")]
+    replication_factor: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ApiBlockVolume {
+    #[serde(default)]
+    uuid: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default, alias = "poolUuid", alias = "pool", alias = "pool_uuid")]
+    pool_uuid: Option<String>,
+    #[serde(default, alias = "sizeBytes", alias = "size_bytes")]
+    size_bytes: Option<u64>,
+    #[serde(default)]
+    protection: Option<ApiProtection>,
+}
+
+/// API subscriber. Owns an HTTP client + the local store.
+pub struct ApiSubscriber {
+    cfg: ApiSubscriberConfig,
+    http: reqwest::Client,
+    store: Store,
+}
+
+impl ApiSubscriber {
+    pub fn new(cfg: ApiSubscriberConfig, store: Store) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()?;
+        Ok(Self { cfg, http, store })
+    }
+
+    /// Run the loop forever. Cancellable via the parent task being dropped.
+    pub async fn run(self) -> Result<()> {
+        let mut iv = tokio::time::interval(self.cfg.poll_interval);
+        iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            iv.tick().await;
+            if let Err(e) = self.tick().await {
+                warn!(error = %e, "api subscriber tick failed");
+            }
+        }
+    }
+
+    /// Single reconciliation pass. Public for tests.
+    pub async fn tick(&self) -> Result<()> {
+        self.reconcile_pools().await?;
+        self.reconcile_disks().await?;
+        self.reconcile_volumes().await?;
+        Ok(())
+    }
+
+    async fn fetch_json<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<Vec<T>> {
+        let url = format!("{}{}", self.cfg.base_url.trim_end_matches('/'), path);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {url}"))?;
+        if !resp.status().is_success() {
+            anyhow::bail!("GET {url} returned {}", resp.status());
+        }
+        let bytes = resp.bytes().await?;
+        // Accept both `{"items": [...]}` and a raw array.
+        if let Ok(items) = serde_json::from_slice::<Vec<T>>(&bytes) {
+            return Ok(items);
+        }
+        #[derive(Deserialize)]
+        struct Wrap<T> {
+            #[serde(default = "Vec::new")]
+            items: Vec<T>,
+        }
+        let w: Wrap<T> = serde_json::from_slice(&bytes)
+            .with_context(|| format!("decode response from {url}"))?;
+        Ok(w.items)
+    }
+
+    async fn reconcile_pools(&self) -> Result<()> {
+        let api_pools: Vec<ApiPool> = self.fetch_json("/api/v1/pools").await?;
+        for ap in api_pools {
+            if ap.uuid.is_empty() {
+                continue;
+            }
+            let new_p = Pool {
+                uuid: ap.uuid.clone(),
+                name: if ap.name.is_empty() {
+                    ap.uuid.clone()
+                } else {
+                    ap.name
+                },
+                replication_factor: ap.replication_factor.unwrap_or(2).max(1),
+                tier: ap.tier.unwrap_or_default(),
+                generation: 1,
+            };
+            let cur = self.store.get_pool(&new_p.uuid)?;
+            match cur {
+                Some(c) if pools_equivalent(&c, &new_p) => {}
+                Some(c) => {
+                    let mut updated = new_p.clone();
+                    updated.generation = c.generation + 1;
+                    self.store.put_pool(&updated)?;
+                    debug!(uuid = %updated.uuid, "pool updated");
+                }
+                None => {
+                    self.store.put_pool(&new_p)?;
+                    info!(uuid = %new_p.uuid, "pool added");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn reconcile_disks(&self) -> Result<()> {
+        let api_disks: Vec<ApiDisk> = self.fetch_json("/api/v1/disks").await?;
+        for ad in api_disks {
+            if ad.uuid.is_empty() {
+                continue;
+            }
+            let new_pool = ad.pool_uuid.clone().unwrap_or_default();
+            let new_state = ad.state.clone().unwrap_or_else(|| {
+                if new_pool.is_empty() {
+                    "unclaimed".into()
+                } else {
+                    "claiming".into()
+                }
+            });
+            let new_d = Disk {
+                uuid: ad.uuid.clone(),
+                node: ad
+                    .node
+                    .clone()
+                    .unwrap_or_else(|| self.cfg.node_name.clone()),
+                device_path: ad.device_path.clone().unwrap_or_default(),
+                size_bytes: ad.size_bytes.unwrap_or(0),
+                pool_uuid: new_pool.clone(),
+                state: new_state,
+                tier: ad.tier.clone().unwrap_or_default(),
+                present: ad.present.unwrap_or(true),
+                generation: 1,
+            };
+            let cur = self.store.get_disk(&new_d.uuid)?;
+            match cur {
+                Some(c) if disks_equivalent(&c, &new_d) => {}
+                Some(c) => {
+                    let mut updated = new_d.clone();
+                    updated.generation = c.generation + 1;
+                    // Preserve state if newer assignment matches existing.
+                    self.store.put_disk(&updated)?;
+                    if c.pool_uuid != new_d.pool_uuid && !new_d.pool_uuid.is_empty() {
+                        self.enqueue_claim(&updated)?;
+                    }
+                }
+                None => {
+                    self.store.put_disk(&new_d)?;
+                    if !new_d.pool_uuid.is_empty() {
+                        self.enqueue_claim(&new_d)?;
+                    }
+                    info!(uuid = %new_d.uuid, "disk added");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn enqueue_claim(&self, d: &Disk) -> Result<()> {
+        // Suppress duplicate ClaimDisk tasks for the same disk.
+        let already = self.store.task_exists_for(|t| {
+            matches!(&t.payload, TaskPayload::ClaimDisk { disk_uuid, .. } if disk_uuid == &d.uuid)
+        })?;
+        if already {
+            return Ok(());
+        }
+        let task = Task {
+            id: uuid::Uuid::new_v4().to_string(),
+            created_unix_secs: now_secs(),
+            payload: TaskPayload::ClaimDisk {
+                disk_uuid: d.uuid.clone(),
+                pool_uuid: d.pool_uuid.clone(),
+            },
+        };
+        self.store.put_task(&task)?;
+        info!(disk = %d.uuid, pool = %d.pool_uuid, "claim task enqueued");
+        Ok(())
+    }
+
+    async fn reconcile_volumes(&self) -> Result<()> {
+        let api_vols: Vec<ApiBlockVolume> = self.fetch_json("/api/v1/block-volumes").await?;
+        for av in api_vols {
+            if av.uuid.is_empty() {
+                continue;
+            }
+            let pool_uuid = av.pool_uuid.clone().unwrap_or_default();
+            if pool_uuid.is_empty() {
+                continue;
+            }
+            if self.store.get_volume(&av.uuid)?.is_some() {
+                continue; // volumes are immutable from the meta side
+            }
+            let pool = match self.store.get_pool(&pool_uuid)? {
+                Some(p) => p,
+                None => {
+                    warn!(volume = %av.uuid, pool = %pool_uuid, "volume references unknown pool, skipping");
+                    continue;
+                }
+            };
+            let size = av.size_bytes.unwrap_or(0);
+            if size == 0 {
+                warn!(volume = %av.uuid, "volume size_bytes=0, skipping");
+                continue;
+            }
+            let rf = av
+                .protection
+                .as_ref()
+                .and_then(|p| p.replication_factor)
+                .unwrap_or(pool.replication_factor)
+                .max(1);
+            let topo = pool_topology(&self.store, &pool_uuid)?;
+            if (topo.len() as u32) < rf {
+                warn!(
+                    volume = %av.uuid,
+                    pool = %pool_uuid,
+                    have = topo.len(),
+                    need = rf,
+                    "not enough disks for volume yet"
+                );
+                continue;
+            }
+            let chunk_count = crate::chunk_count_for(size);
+            let mut placements = Vec::with_capacity(chunk_count as usize);
+            for i in 0..chunk_count {
+                let key = crush::chunk_key(&av.uuid, i as u32);
+                let disks = match crush::select(&key, rf as usize, &topo) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        warn!(volume = %av.uuid, error = %e, "CRUSH placement failed");
+                        return Ok(());
+                    }
+                };
+                placements.push(ChunkPlacement {
+                    index: i as u32,
+                    chunk_id: String::new(),
+                    disk_uuids: disks,
+                });
+            }
+            let v = Volume {
+                uuid: av.uuid.clone(),
+                name: if av.name.is_empty() {
+                    av.uuid.clone()
+                } else {
+                    av.name
+                },
+                pool_uuid,
+                size_bytes: size,
+                protection: ProtectionSpec {
+                    replication_factor: rf,
+                },
+                chunk_size_bytes: CHUNK_SIZE_BYTES,
+                chunk_count,
+                generation: 1,
+            };
+            self.store.put_volume(&v)?;
+            self.store.put_chunk_map(&v.uuid, &placements)?;
+            info!(uuid = %v.uuid, chunks = chunk_count, "volume created via api subscriber");
+        }
+        Ok(())
+    }
+}
+
+fn pools_equivalent(a: &Pool, b: &Pool) -> bool {
+    a.uuid == b.uuid
+        && a.name == b.name
+        && a.replication_factor == b.replication_factor
+        && a.tier == b.tier
+}
+
+fn disks_equivalent(a: &Disk, b: &Disk) -> bool {
+    a.uuid == b.uuid
+        && a.node == b.node
+        && a.device_path == b.device_path
+        && a.size_bytes == b.size_bytes
+        && a.pool_uuid == b.pool_uuid
+        && a.state == b.state
+        && a.tier == b.tier
+        && a.present == b.present
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default()
+}

--- a/storage/meta/src/crush.rs
+++ b/storage/meta/src/crush.rs
@@ -1,0 +1,147 @@
+//! CRUSH straw2 placement, adapted for a single host.
+//!
+//! Failure domain = disk. The topology is a flat list of `(disk_uuid, weight)`
+//! per pool. The algorithm is the same straw2 used by the dataplane crate;
+//! this module is the meta-side, single-host counterpart.
+
+use ring::digest;
+
+use crate::topology::PoolTopology;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CrushError {
+    #[error("not enough disks for replication factor: have {have}, need {need}")]
+    InsufficientDisks { have: usize, need: usize },
+}
+
+/// Select `count` distinct disks for the given chunk key.
+pub fn select(
+    chunk_key: &str,
+    count: usize,
+    topology: &PoolTopology,
+) -> Result<Vec<String>, CrushError> {
+    if topology.disks.len() < count {
+        return Err(CrushError::InsufficientDisks {
+            have: topology.disks.len(),
+            need: count,
+        });
+    }
+    let mut candidates: Vec<&crate::topology::DiskCandidate> = topology.disks.iter().collect();
+    let mut out = Vec::with_capacity(count);
+
+    for replica in 0..count {
+        let best = candidates
+            .iter()
+            .enumerate()
+            .map(|(idx, d)| (idx, straw2_draw(chunk_key, &d.disk_uuid, replica, d.weight)))
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        if let Some((best_idx, _)) = best {
+            let chosen = candidates.remove(best_idx);
+            out.push(chosen.disk_uuid.clone());
+        }
+    }
+    Ok(out)
+}
+
+fn straw2_draw(chunk_key: &str, candidate_id: &str, replica: usize, weight: u64) -> f64 {
+    let hash = crush_hash(chunk_key, candidate_id, replica);
+    let draw = (hash as f64 + 0.5) / (u32::MAX as f64 + 1.0);
+    draw.ln() / weight.max(1) as f64
+}
+
+fn crush_hash(chunk_key: &str, candidate_id: &str, replica: usize) -> u32 {
+    let mut ctx = digest::Context::new(&digest::SHA256);
+    ctx.update(chunk_key.as_bytes());
+    ctx.update(b":");
+    ctx.update(candidate_id.as_bytes());
+    ctx.update(b":");
+    let mut buf = [0u8; 20];
+    let len = {
+        use std::io::Write;
+        let mut cursor = std::io::Cursor::new(&mut buf[..]);
+        write!(cursor, "{}", replica).unwrap();
+        cursor.position() as usize
+    };
+    ctx.update(&buf[..len]);
+    let result = ctx.finish();
+    let bytes = result.as_ref();
+    u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+/// Build the chunk key from `(volume_uuid, chunk_index)`.
+pub fn chunk_key(volume_uuid: &str, chunk_index: u32) -> String {
+    format!("{volume_uuid}/{chunk_index}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn topo(n: usize) -> PoolTopology {
+        let mut t = PoolTopology::new("pool");
+        for i in 0..n {
+            t.push(format!("disk-{i}"), 100);
+        }
+        t
+    }
+
+    #[test]
+    fn select_returns_requested_count() {
+        let t = topo(5);
+        let p = select("k", 3, &t).unwrap();
+        assert_eq!(p.len(), 3);
+    }
+
+    #[test]
+    fn select_is_deterministic() {
+        let t = topo(5);
+        let a = select("k", 3, &t).unwrap();
+        let b = select("k", 3, &t).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn select_distinct_disks() {
+        let t = topo(5);
+        let p = select("k", 3, &t).unwrap();
+        let mut seen = std::collections::HashSet::new();
+        for d in &p {
+            assert!(seen.insert(d.clone()), "duplicate disk: {d}");
+        }
+    }
+
+    #[test]
+    fn select_insufficient_disks_errors() {
+        let t = topo(2);
+        let e = select("k", 3, &t).unwrap_err();
+        matches!(e, CrushError::InsufficientDisks { .. });
+    }
+
+    #[test]
+    fn select_distributes() {
+        let t = topo(4);
+        let mut counts = std::collections::HashMap::<String, usize>::new();
+        for i in 0..1000 {
+            let p = select(&format!("k-{i}"), 1, &t).unwrap();
+            *counts.entry(p[0].clone()).or_insert(0) += 1;
+        }
+        for c in counts.values() {
+            assert!((150..=350).contains(c), "got {c}, expected 150-350");
+        }
+    }
+
+    #[test]
+    fn select_respects_weight() {
+        let mut t = PoolTopology::new("pool");
+        t.push("heavy", 900);
+        t.push("light", 100);
+        let mut heavy = 0;
+        for i in 0..1000 {
+            let p = select(&format!("k-{i}"), 1, &t).unwrap();
+            if p[0] == "heavy" {
+                heavy += 1;
+            }
+        }
+        assert!(heavy > 800, "heavy got {heavy}");
+    }
+}

--- a/storage/meta/src/lib.rs
+++ b/storage/meta/src/lib.rs
@@ -1,0 +1,59 @@
+//! novanas-meta: single-host cold-path metadata daemon.
+//!
+//! This crate is the source of placement and lifecycle truth for the local
+//! data daemon in architecture-v2. It subscribes to `novanas-api` for the
+//! authoritative pool/disk/volume state, persists chunk maps in redb, runs
+//! the CRUSH placement algorithm, and emits tasks for the data daemon.
+//!
+//! The crate is deliberately decoupled from the dataplane crate (which is
+//! SPDK-gated and cannot be linked from non-Linux hosts).
+
+pub mod api_client;
+pub mod crush;
+pub mod policy;
+pub mod server;
+pub mod store;
+pub mod topology;
+pub mod types;
+
+/// Generated tonic types for the meta gRPC service.
+pub mod proto {
+    tonic::include_proto!("novanas.meta.v1");
+}
+
+/// Hard-coded chunk size: 4 MiB.
+pub const CHUNK_SIZE_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Compute chunk count for a volume of `size_bytes`.
+pub fn chunk_count_for(size_bytes: u64) -> u64 {
+    if size_bytes == 0 {
+        0
+    } else {
+        size_bytes.div_ceil(CHUNK_SIZE_BYTES)
+    }
+}
+
+#[cfg(test)]
+mod lib_tests {
+    use super::*;
+
+    #[test]
+    fn chunk_count_zero_size() {
+        assert_eq!(chunk_count_for(0), 0);
+    }
+
+    #[test]
+    fn chunk_count_exact_chunk() {
+        assert_eq!(chunk_count_for(CHUNK_SIZE_BYTES), 1);
+    }
+
+    #[test]
+    fn chunk_count_partial_chunk() {
+        assert_eq!(chunk_count_for(CHUNK_SIZE_BYTES + 1), 2);
+    }
+
+    #[test]
+    fn chunk_count_many() {
+        assert_eq!(chunk_count_for(10 * CHUNK_SIZE_BYTES), 10);
+    }
+}

--- a/storage/meta/src/main.rs
+++ b/storage/meta/src/main.rs
@@ -1,0 +1,139 @@
+//! novanas-meta entrypoint.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use tokio::net::{TcpListener, UnixListener};
+use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
+use tonic::transport::Server;
+use tracing::info;
+
+use novanas_meta::api_client::{ApiSubscriber, ApiSubscriberConfig};
+use novanas_meta::policy::{PolicyChecker, PolicyConfig};
+use novanas_meta::server::MetaServer;
+use novanas_meta::store::Store;
+
+#[derive(Debug, Parser)]
+#[command(name = "novanas-meta", about = "NovaNAS metadata daemon")]
+struct Args {
+    /// Persistent state directory.
+    #[arg(long, default_value = "/var/lib/novanas-meta")]
+    data_dir: PathBuf,
+
+    /// Path to the Unix socket the gRPC server listens on.
+    #[arg(long, default_value = "/var/run/novanas/meta.sock")]
+    listen_uds: PathBuf,
+
+    /// Optional TCP listen address (e.g. 127.0.0.1:7777). Useful for tests.
+    #[arg(long)]
+    listen_tcp: Option<String>,
+
+    /// Base URL of `novanas-api`.
+    #[arg(long, default_value = "http://localhost:3000")]
+    api_url: String,
+
+    /// API poll interval, in seconds.
+    #[arg(long, default_value_t = 5)]
+    api_poll_secs: u64,
+
+    /// Policy check interval, in seconds.
+    #[arg(long, default_value_t = 30)]
+    policy_secs: u64,
+
+    /// Local node name. Single-host architecture, but disks carry a node
+    /// label for symmetry with the API schema.
+    #[arg(long, default_value = "local")]
+    node_name: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,novanas_meta=debug".into()),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    std::fs::create_dir_all(&args.data_dir)
+        .with_context(|| format!("create data dir {}", args.data_dir.display()))?;
+    let store_path = args.data_dir.join("meta.redb");
+    let store = Store::open(&store_path)
+        .with_context(|| format!("open redb at {}", store_path.display()))?;
+    info!(path = %store_path.display(), "store opened");
+
+    // ----- gRPC server -------------------------------------------------
+    let svc = MetaServer::new(store.clone()).into_service();
+
+    let server_handle: tokio::task::JoinHandle<Result<()>> = if let Some(addr) = &args.listen_tcp {
+        let listener = TcpListener::bind(addr)
+            .await
+            .with_context(|| format!("bind tcp {addr}"))?;
+        info!(addr = %addr, "gRPC listening (tcp)");
+        let stream = TcpListenerStream::new(listener);
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(svc)
+                .serve_with_incoming(stream)
+                .await
+                .context("grpc server (tcp) crashed")
+        })
+    } else {
+        if let Some(parent) = args.listen_uds.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create uds parent dir {}", parent.display()))?;
+        }
+        let _ = std::fs::remove_file(&args.listen_uds);
+        let uds = UnixListener::bind(&args.listen_uds)
+            .with_context(|| format!("bind uds {}", args.listen_uds.display()))?;
+        info!(path = %args.listen_uds.display(), "gRPC listening (uds)");
+        let stream = UnixListenerStream::new(uds);
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(svc)
+                .serve_with_incoming(stream)
+                .await
+                .context("grpc server (uds) crashed")
+        })
+    };
+
+    // ----- API subscriber ---------------------------------------------
+    let api_cfg = ApiSubscriberConfig {
+        base_url: args.api_url,
+        poll_interval: Duration::from_secs(args.api_poll_secs),
+        node_name: args.node_name,
+    };
+    let api = ApiSubscriber::new(api_cfg, store.clone()).context("build api subscriber")?;
+    let api_handle = tokio::spawn(async move {
+        if let Err(e) = api.run().await {
+            tracing::error!(error = %e, "api subscriber exited");
+        }
+    });
+
+    // ----- Policy loop ------------------------------------------------
+    let policy = PolicyChecker::new(
+        PolicyConfig {
+            interval: Duration::from_secs(args.policy_secs),
+        },
+        store.clone(),
+    );
+    let policy_handle = tokio::spawn(async move {
+        if let Err(e) = policy.run().await {
+            tracing::error!(error = %e, "policy checker exited");
+        }
+    });
+
+    // Block on the gRPC server task; it should run forever.
+    match server_handle.await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return Err(e),
+        Err(e) => return Err(anyhow::anyhow!("server join error: {e}")),
+    }
+    api_handle.abort();
+    policy_handle.abort();
+    Ok(())
+}

--- a/storage/meta/src/policy.rs
+++ b/storage/meta/src/policy.rs
@@ -1,0 +1,325 @@
+//! Timer-driven policy checker.
+//!
+//! Walks every volume's chunk map and ensures replication-factor compliance.
+//! When a chunk has fewer healthy copies than its volume's protection spec
+//! requires (or copies on degraded disks), enqueue a `REPLICATE_CHUNK` task
+//! pointing at fresh CRUSH-selected target disks.
+//!
+//! Tier migration is a future hook; the loop body has a clearly-named branch
+//! for it but does not emit tasks in this PR.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use anyhow::Result;
+use tracing::{debug, info, warn};
+
+use crate::crush;
+use crate::server::pool_topology;
+use crate::store::Store;
+use crate::types::{ChunkPlacement, Disk, Task, TaskPayload};
+
+#[derive(Debug, Clone)]
+pub struct PolicyConfig {
+    pub interval: Duration,
+}
+
+impl Default for PolicyConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(30),
+        }
+    }
+}
+
+pub struct PolicyChecker {
+    cfg: PolicyConfig,
+    store: Store,
+}
+
+impl PolicyChecker {
+    pub fn new(cfg: PolicyConfig, store: Store) -> Self {
+        Self { cfg, store }
+    }
+
+    pub async fn run(self) -> Result<()> {
+        let mut iv = tokio::time::interval(self.cfg.interval);
+        iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            iv.tick().await;
+            if let Err(e) = self.tick() {
+                warn!(error = %e, "policy tick failed");
+            }
+        }
+    }
+
+    /// One reconciliation pass. Public so tests can drive it.
+    pub fn tick(&self) -> Result<()> {
+        let disks: HashMap<String, Disk> = self
+            .store
+            .list_disks()?
+            .into_iter()
+            .map(|d| (d.uuid.clone(), d))
+            .collect();
+        let volumes = self.store.list_volumes()?;
+        for v in volumes {
+            let cm = self.store.get_chunk_map(&v.uuid)?;
+            let topo = pool_topology(&self.store, &v.pool_uuid)?;
+            let healthy_set: HashSet<String> =
+                topo.disks.iter().map(|d| d.disk_uuid.clone()).collect();
+            for chunk in &cm.chunks {
+                let healthy_copies: Vec<&String> = chunk
+                    .disk_uuids
+                    .iter()
+                    .filter(|d| {
+                        healthy_set.contains(*d)
+                            && disks.get(*d).map(|x| x.present).unwrap_or(false)
+                    })
+                    .collect();
+                let required = v.protection.replication_factor as usize;
+                if healthy_copies.len() < required {
+                    self.enqueue_replicate(&v.uuid, chunk, &topo, required)?;
+                }
+                // Future hook: tier migration.
+                self.maybe_tier_migrate(&v, chunk);
+            }
+        }
+        Ok(())
+    }
+
+    fn enqueue_replicate(
+        &self,
+        volume_uuid: &str,
+        chunk: &ChunkPlacement,
+        topo: &crate::topology::PoolTopology,
+        required: usize,
+    ) -> Result<()> {
+        // Pick fresh placement; CRUSH is deterministic so the source set is
+        // either a subset of the new picks (already-placed copies) or
+        // disjoint (everything has moved). The data daemon does the actual
+        // copy + record-update.
+        let key = crush::chunk_key(volume_uuid, chunk.index);
+        let target_count = required.min(topo.len());
+        if target_count == 0 {
+            warn!(volume = %volume_uuid, chunk = chunk.index, "no eligible disks for replication");
+            return Ok(());
+        }
+        let targets = match crush::select(&key, target_count, topo) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(volume = %volume_uuid, error = %e, "CRUSH replicate selection failed");
+                return Ok(());
+            }
+        };
+        let already = self.store.task_exists_for(|t| match &t.payload {
+            TaskPayload::ReplicateChunk {
+                volume_uuid: vu,
+                chunk_index,
+                ..
+            } => vu == volume_uuid && *chunk_index == chunk.index,
+            _ => false,
+        })?;
+        if already {
+            debug!(volume = %volume_uuid, chunk = chunk.index, "replicate task already pending");
+            return Ok(());
+        }
+        let task = Task {
+            id: uuid::Uuid::new_v4().to_string(),
+            created_unix_secs: now_secs(),
+            payload: TaskPayload::ReplicateChunk {
+                volume_uuid: volume_uuid.to_string(),
+                chunk_index: chunk.index,
+                source_disk_uuids: chunk.disk_uuids.clone(),
+                target_disk_uuids: targets,
+            },
+        };
+        self.store.put_task(&task)?;
+        info!(volume = %volume_uuid, chunk = chunk.index, "replicate task enqueued");
+        Ok(())
+    }
+
+    /// Future hook: tier migration. Not emitted in this PR; leaving the
+    /// branch named so the next agent can fill it in without grepping for
+    /// TODOs.
+    #[inline]
+    fn maybe_tier_migrate(&self, _v: &crate::types::Volume, _chunk: &ChunkPlacement) {
+        // Intentionally empty. Tier migration tasks are out of scope for the
+        // architecture-v2 meta initial PR.
+    }
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Pool, ProtectionSpec, Volume};
+
+    fn temp_store() -> Store {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.redb");
+        let leaked: &'static tempfile::TempDir = Box::leak(Box::new(dir));
+        let _ = leaked.path();
+        Store::open(path).unwrap()
+    }
+
+    fn mk_disk(uuid: &str, pool: &str, present: bool, state: &str) -> Disk {
+        Disk {
+            uuid: uuid.into(),
+            node: "n".into(),
+            device_path: "/dev/x".into(),
+            size_bytes: 10 * 1024 * 1024 * 1024,
+            pool_uuid: pool.into(),
+            state: state.into(),
+            tier: "fast".into(),
+            present,
+            generation: 1,
+        }
+    }
+
+    #[test]
+    fn policy_emits_replicate_when_under_replicated() {
+        let s = temp_store();
+        let pool = Pool {
+            uuid: "p".into(),
+            name: "p".into(),
+            replication_factor: 2,
+            tier: "fast".into(),
+            generation: 1,
+        };
+        s.put_pool(&pool).unwrap();
+        for i in 0..3 {
+            s.put_disk(&mk_disk(&format!("d{i}"), "p", true, "ready"))
+                .unwrap();
+        }
+        let vol = Volume {
+            uuid: "v".into(),
+            name: "v".into(),
+            pool_uuid: "p".into(),
+            size_bytes: 4 * 1024 * 1024,
+            protection: ProtectionSpec {
+                replication_factor: 2,
+            },
+            chunk_size_bytes: 4 * 1024 * 1024,
+            chunk_count: 1,
+            generation: 1,
+        };
+        s.put_volume(&vol).unwrap();
+        // Place chunk on only ONE disk -> under-replicated.
+        s.put_chunk_map(
+            "v",
+            &[ChunkPlacement {
+                index: 0,
+                chunk_id: String::new(),
+                disk_uuids: vec!["d0".into()],
+            }],
+        )
+        .unwrap();
+
+        let p = PolicyChecker::new(PolicyConfig::default(), s.clone());
+        p.tick().unwrap();
+        let tasks = s.list_tasks().unwrap();
+        assert_eq!(tasks.len(), 1);
+        match &tasks[0].payload {
+            TaskPayload::ReplicateChunk {
+                volume_uuid,
+                chunk_index,
+                ..
+            } => {
+                assert_eq!(volume_uuid, "v");
+                assert_eq!(*chunk_index, 0);
+            }
+            _ => panic!("expected replicate task"),
+        }
+    }
+
+    #[test]
+    fn policy_does_not_double_emit() {
+        let s = temp_store();
+        let pool = Pool {
+            uuid: "p".into(),
+            name: "p".into(),
+            replication_factor: 2,
+            tier: "fast".into(),
+            generation: 1,
+        };
+        s.put_pool(&pool).unwrap();
+        for i in 0..3 {
+            s.put_disk(&mk_disk(&format!("d{i}"), "p", true, "ready"))
+                .unwrap();
+        }
+        let vol = Volume {
+            uuid: "v".into(),
+            name: "v".into(),
+            pool_uuid: "p".into(),
+            size_bytes: 4 * 1024 * 1024,
+            protection: ProtectionSpec {
+                replication_factor: 2,
+            },
+            chunk_size_bytes: 4 * 1024 * 1024,
+            chunk_count: 1,
+            generation: 1,
+        };
+        s.put_volume(&vol).unwrap();
+        s.put_chunk_map(
+            "v",
+            &[ChunkPlacement {
+                index: 0,
+                chunk_id: String::new(),
+                disk_uuids: vec!["d0".into()],
+            }],
+        )
+        .unwrap();
+        let p = PolicyChecker::new(PolicyConfig::default(), s.clone());
+        p.tick().unwrap();
+        p.tick().unwrap();
+        assert_eq!(s.list_tasks().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn policy_compliant_emits_nothing() {
+        let s = temp_store();
+        let pool = Pool {
+            uuid: "p".into(),
+            name: "p".into(),
+            replication_factor: 2,
+            tier: "fast".into(),
+            generation: 1,
+        };
+        s.put_pool(&pool).unwrap();
+        for i in 0..3 {
+            s.put_disk(&mk_disk(&format!("d{i}"), "p", true, "ready"))
+                .unwrap();
+        }
+        let vol = Volume {
+            uuid: "v".into(),
+            name: "v".into(),
+            pool_uuid: "p".into(),
+            size_bytes: 4 * 1024 * 1024,
+            protection: ProtectionSpec {
+                replication_factor: 2,
+            },
+            chunk_size_bytes: 4 * 1024 * 1024,
+            chunk_count: 1,
+            generation: 1,
+        };
+        s.put_volume(&vol).unwrap();
+        s.put_chunk_map(
+            "v",
+            &[ChunkPlacement {
+                index: 0,
+                chunk_id: String::new(),
+                disk_uuids: vec!["d0".into(), "d1".into()],
+            }],
+        )
+        .unwrap();
+        let p = PolicyChecker::new(PolicyConfig::default(), s.clone());
+        p.tick().unwrap();
+        assert_eq!(s.list_tasks().unwrap().len(), 0);
+    }
+}

--- a/storage/meta/src/server.rs
+++ b/storage/meta/src/server.rs
@@ -1,0 +1,410 @@
+//! gRPC server: implements `MetaService` over redb-backed `Store`.
+//!
+//! The server is transport-agnostic: bind it to either a `UnixListener`
+//! (default in production) or a `TcpListener` (default for tests).
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tonic::{Request, Response, Status};
+use tracing::{debug, info};
+
+use crate::crush;
+use crate::proto::meta_service_server::{MetaService, MetaServiceServer};
+use crate::proto::{self, *};
+use crate::store::Store;
+use crate::topology::PoolTopology;
+use crate::types::{self, ChunkPlacement, Disk, Pool, ProtectionSpec, Task, TaskPayload, Volume};
+
+/// gRPC service implementation.
+pub struct MetaServer {
+    store: Store,
+}
+
+impl MetaServer {
+    pub fn new(store: Store) -> Self {
+        Self { store }
+    }
+
+    pub fn into_service(self) -> MetaServiceServer<Self> {
+        MetaServiceServer::new(self)
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default()
+}
+
+fn map_err<E: std::fmt::Display>(e: E) -> Status {
+    Status::internal(e.to_string())
+}
+
+/// Build a `PoolTopology` for placement out of the disks belonging to a pool
+/// and currently present + ready.
+pub fn pool_topology(store: &Store, pool_uuid: &str) -> anyhow::Result<PoolTopology> {
+    let mut topo = PoolTopology::new(pool_uuid.to_string());
+    for d in store.list_disks_for_pool(pool_uuid)? {
+        if d.present && (d.state == "ready" || d.state == "claiming") {
+            // Weight by GiB.
+            let gib = (d.size_bytes / (1024 * 1024 * 1024)).max(1);
+            topo.push(d.uuid.clone(), gib);
+        }
+    }
+    Ok(topo)
+}
+
+#[tonic::async_trait]
+impl MetaService for MetaServer {
+    // --- Pools ----------------------------------------------------------
+
+    async fn put_pool(
+        &self,
+        req: Request<PutPoolRequest>,
+    ) -> Result<Response<PutPoolResponse>, Status> {
+        let pool = req
+            .into_inner()
+            .pool
+            .ok_or_else(|| Status::invalid_argument("pool missing"))?;
+        if pool.uuid.is_empty() {
+            return Err(Status::invalid_argument("pool.uuid empty"));
+        }
+        let mut p: Pool = pool.into();
+        p.generation = p.generation.max(1);
+        self.store.put_pool(&p).map_err(map_err)?;
+        debug!(uuid = %p.uuid, "pool put");
+        Ok(Response::new(PutPoolResponse {
+            pool: Some(p.into()),
+        }))
+    }
+
+    async fn get_pool(
+        &self,
+        req: Request<GetPoolRequest>,
+    ) -> Result<Response<GetPoolResponse>, Status> {
+        let uuid = req.into_inner().uuid;
+        let p = self
+            .store
+            .get_pool(&uuid)
+            .map_err(map_err)?
+            .ok_or_else(|| Status::not_found(format!("pool {uuid} not found")))?;
+        Ok(Response::new(GetPoolResponse {
+            pool: Some(p.into()),
+        }))
+    }
+
+    async fn list_pools(
+        &self,
+        _req: Request<ListPoolsRequest>,
+    ) -> Result<Response<ListPoolsResponse>, Status> {
+        let pools = self
+            .store
+            .list_pools()
+            .map_err(map_err)?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        Ok(Response::new(ListPoolsResponse { pools }))
+    }
+
+    async fn delete_pool(
+        &self,
+        req: Request<DeletePoolRequest>,
+    ) -> Result<Response<DeletePoolResponse>, Status> {
+        self.store
+            .delete_pool(&req.into_inner().uuid)
+            .map_err(map_err)?;
+        Ok(Response::new(DeletePoolResponse {}))
+    }
+
+    // --- Disks ----------------------------------------------------------
+
+    async fn put_disk(
+        &self,
+        req: Request<PutDiskRequest>,
+    ) -> Result<Response<PutDiskResponse>, Status> {
+        let disk = req
+            .into_inner()
+            .disk
+            .ok_or_else(|| Status::invalid_argument("disk missing"))?;
+        if disk.uuid.is_empty() {
+            return Err(Status::invalid_argument("disk.uuid empty"));
+        }
+        let mut d: Disk = disk.into();
+        d.generation = d.generation.max(1);
+        self.store.put_disk(&d).map_err(map_err)?;
+        Ok(Response::new(PutDiskResponse {
+            disk: Some(d.into()),
+        }))
+    }
+
+    async fn get_disk(
+        &self,
+        req: Request<GetDiskRequest>,
+    ) -> Result<Response<GetDiskResponse>, Status> {
+        let uuid = req.into_inner().uuid;
+        let d = self
+            .store
+            .get_disk(&uuid)
+            .map_err(map_err)?
+            .ok_or_else(|| Status::not_found(format!("disk {uuid} not found")))?;
+        Ok(Response::new(GetDiskResponse {
+            disk: Some(d.into()),
+        }))
+    }
+
+    async fn list_disks(
+        &self,
+        req: Request<ListDisksRequest>,
+    ) -> Result<Response<ListDisksResponse>, Status> {
+        let pool = req.into_inner().pool_uuid;
+        let disks = if pool.is_empty() {
+            self.store.list_disks().map_err(map_err)?
+        } else {
+            self.store.list_disks_for_pool(&pool).map_err(map_err)?
+        };
+        Ok(Response::new(ListDisksResponse {
+            disks: disks.into_iter().map(Into::into).collect(),
+        }))
+    }
+
+    async fn delete_disk(
+        &self,
+        req: Request<DeleteDiskRequest>,
+    ) -> Result<Response<DeleteDiskResponse>, Status> {
+        self.store
+            .delete_disk(&req.into_inner().uuid)
+            .map_err(map_err)?;
+        Ok(Response::new(DeleteDiskResponse {}))
+    }
+
+    // --- Volumes --------------------------------------------------------
+
+    async fn create_volume(
+        &self,
+        req: Request<CreateVolumeRequest>,
+    ) -> Result<Response<CreateVolumeResponse>, Status> {
+        let r = req.into_inner();
+        if r.uuid.is_empty() {
+            return Err(Status::invalid_argument("uuid empty"));
+        }
+        if r.size_bytes == 0 {
+            return Err(Status::invalid_argument("size_bytes must be > 0"));
+        }
+        let pool = self
+            .store
+            .get_pool(&r.pool_uuid)
+            .map_err(map_err)?
+            .ok_or_else(|| Status::not_found(format!("pool {} not found", r.pool_uuid)))?;
+        let prot: ProtectionSpec = r.protection.map(Into::into).unwrap_or(ProtectionSpec {
+            replication_factor: pool.replication_factor,
+        });
+        let rf = if prot.replication_factor == 0 {
+            pool.replication_factor
+        } else {
+            prot.replication_factor
+        };
+        let topo = pool_topology(&self.store, &r.pool_uuid).map_err(map_err)?;
+        if (topo.len() as u32) < rf {
+            return Err(Status::failed_precondition(format!(
+                "pool {} has {} eligible disks, need {}",
+                r.pool_uuid,
+                topo.len(),
+                rf
+            )));
+        }
+        let chunk_count = crate::chunk_count_for(r.size_bytes);
+        let mut placements = Vec::with_capacity(chunk_count as usize);
+        for i in 0..chunk_count {
+            let key = crush::chunk_key(&r.uuid, i as u32);
+            let disks = crush::select(&key, rf as usize, &topo)
+                .map_err(|e| Status::failed_precondition(format!("CRUSH placement failed: {e}")))?;
+            placements.push(ChunkPlacement {
+                index: i as u32,
+                chunk_id: String::new(),
+                disk_uuids: disks,
+            });
+        }
+
+        let v = Volume {
+            uuid: r.uuid.clone(),
+            name: r.name,
+            pool_uuid: r.pool_uuid,
+            size_bytes: r.size_bytes,
+            protection: ProtectionSpec {
+                replication_factor: rf,
+            },
+            chunk_size_bytes: crate::CHUNK_SIZE_BYTES,
+            chunk_count,
+            generation: 1,
+        };
+        self.store.put_volume(&v).map_err(map_err)?;
+        self.store
+            .put_chunk_map(&v.uuid, &placements)
+            .map_err(map_err)?;
+        info!(uuid = %v.uuid, chunks = chunk_count, "volume created");
+
+        let chunk_map = types::ChunkMap {
+            volume_uuid: v.uuid.clone(),
+            chunks: placements,
+        };
+        Ok(Response::new(CreateVolumeResponse {
+            volume: Some(v.into()),
+            chunk_map: Some(chunk_map.into()),
+        }))
+    }
+
+    async fn get_volume(
+        &self,
+        req: Request<GetVolumeRequest>,
+    ) -> Result<Response<GetVolumeResponse>, Status> {
+        let uuid = req.into_inner().uuid;
+        let v = self
+            .store
+            .get_volume(&uuid)
+            .map_err(map_err)?
+            .ok_or_else(|| Status::not_found(format!("volume {uuid} not found")))?;
+        Ok(Response::new(GetVolumeResponse {
+            volume: Some(v.into()),
+        }))
+    }
+
+    async fn list_volumes(
+        &self,
+        req: Request<ListVolumesRequest>,
+    ) -> Result<Response<ListVolumesResponse>, Status> {
+        let pool = req.into_inner().pool_uuid;
+        let mut vols = self.store.list_volumes().map_err(map_err)?;
+        if !pool.is_empty() {
+            vols.retain(|v| v.pool_uuid == pool);
+        }
+        Ok(Response::new(ListVolumesResponse {
+            volumes: vols.into_iter().map(Into::into).collect(),
+        }))
+    }
+
+    async fn delete_volume(
+        &self,
+        req: Request<DeleteVolumeRequest>,
+    ) -> Result<Response<DeleteVolumeResponse>, Status> {
+        self.store
+            .delete_volume(&req.into_inner().uuid)
+            .map_err(map_err)?;
+        Ok(Response::new(DeleteVolumeResponse {}))
+    }
+
+    async fn get_chunk_map(
+        &self,
+        req: Request<GetChunkMapRequest>,
+    ) -> Result<Response<GetChunkMapResponse>, Status> {
+        let cm = self
+            .store
+            .get_chunk_map(&req.into_inner().volume_uuid)
+            .map_err(map_err)?;
+        Ok(Response::new(GetChunkMapResponse {
+            chunk_map: Some(cm.into()),
+        }))
+    }
+
+    // --- Claim / release -----------------------------------------------
+
+    async fn claim_disk(
+        &self,
+        req: Request<ClaimDiskRequest>,
+    ) -> Result<Response<ClaimDiskResponse>, Status> {
+        let r = req.into_inner();
+        let mut d = self
+            .store
+            .get_disk(&r.disk_uuid)
+            .map_err(map_err)?
+            .ok_or_else(|| Status::not_found(format!("disk {} not found", r.disk_uuid)))?;
+        d.pool_uuid = r.pool_uuid.clone();
+        d.state = "claiming".into();
+        d.generation += 1;
+        self.store.put_disk(&d).map_err(map_err)?;
+        let task = Task {
+            id: uuid::Uuid::new_v4().to_string(),
+            created_unix_secs: now_secs(),
+            payload: TaskPayload::ClaimDisk {
+                disk_uuid: d.uuid.clone(),
+                pool_uuid: r.pool_uuid,
+            },
+        };
+        self.store.put_task(&task).map_err(map_err)?;
+        Ok(Response::new(ClaimDiskResponse {
+            disk: Some(d.into()),
+        }))
+    }
+
+    async fn release_disk(
+        &self,
+        req: Request<ReleaseDiskRequest>,
+    ) -> Result<Response<ReleaseDiskResponse>, Status> {
+        let r = req.into_inner();
+        let mut d = self
+            .store
+            .get_disk(&r.disk_uuid)
+            .map_err(map_err)?
+            .ok_or_else(|| Status::not_found(format!("disk {} not found", r.disk_uuid)))?;
+        d.pool_uuid = String::new();
+        d.state = "unclaimed".into();
+        d.generation += 1;
+        self.store.put_disk(&d).map_err(map_err)?;
+        let task = Task {
+            id: uuid::Uuid::new_v4().to_string(),
+            created_unix_secs: now_secs(),
+            payload: TaskPayload::ReleaseDisk {
+                disk_uuid: d.uuid.clone(),
+            },
+        };
+        self.store.put_task(&task).map_err(map_err)?;
+        Ok(Response::new(ReleaseDiskResponse {
+            disk: Some(d.into()),
+        }))
+    }
+
+    // --- Tasks ---------------------------------------------------------
+
+    async fn poll_tasks(
+        &self,
+        req: Request<PollTasksRequest>,
+    ) -> Result<Response<PollTasksResponse>, Status> {
+        let max = req.into_inner().max as usize;
+        let mut tasks = self.store.list_tasks().map_err(map_err)?;
+        if max > 0 && tasks.len() > max {
+            tasks.truncate(max);
+        }
+        let proto_tasks = tasks.iter().map(|t| t.to_proto()).collect();
+        Ok(Response::new(PollTasksResponse { tasks: proto_tasks }))
+    }
+
+    async fn ack_task(
+        &self,
+        req: Request<AckTaskRequest>,
+    ) -> Result<Response<AckTaskResponse>, Status> {
+        let r = req.into_inner();
+        // Always remove on ack: a failure ack means the data daemon gave up.
+        // Re-emission, if needed, comes from the policy loop.
+        if !r.success {
+            tracing::warn!(task = %r.task_id, error = %r.error, "task acked with failure");
+        }
+        self.store.delete_task(&r.task_id).map_err(map_err)?;
+        Ok(Response::new(AckTaskResponse {}))
+    }
+
+    async fn heartbeat(
+        &self,
+        _req: Request<HeartbeatRequest>,
+    ) -> Result<Response<HeartbeatResponse>, Status> {
+        Ok(Response::new(HeartbeatResponse {
+            server_unix_secs: now_secs(),
+        }))
+    }
+}
+
+// Suppress unused-warn for proto module re-exports used only as type aliases.
+#[allow(dead_code)]
+fn _proto_uses() {
+    let _: Option<proto::Pool> = None;
+}

--- a/storage/meta/src/store.rs
+++ b/storage/meta/src/store.rs
@@ -1,0 +1,463 @@
+//! redb-backed persistent store.
+//!
+//! Tables:
+//!
+//! * `pools`        — `pool_uuid` -> postcard(`Pool`)
+//! * `disks`        — `disk_uuid` -> postcard(`Disk`)
+//! * `volumes`      — `volume_uuid` -> postcard(`Volume`)
+//! * `chunk_maps`   — `volume_uuid|chunk_index` (le bytes) -> postcard(`ChunkPlacement`)
+//! * `tasks`        — `task_id` -> postcard(`Task`)
+//!
+//! Multi-table updates run inside a single redb write transaction, so the
+//! store remains consistent across restarts even on torn writes.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+
+use crate::types::{ChunkMap, ChunkPlacement, Disk, Pool, Task, Volume};
+
+const POOLS: TableDefinition<&str, Vec<u8>> = TableDefinition::new("pools");
+const DISKS: TableDefinition<&str, Vec<u8>> = TableDefinition::new("disks");
+const VOLUMES: TableDefinition<&str, Vec<u8>> = TableDefinition::new("volumes");
+const CHUNK_MAPS: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new("chunk_maps");
+const TASKS: TableDefinition<&str, Vec<u8>> = TableDefinition::new("tasks");
+
+/// Persistent metadata store backed by redb.
+#[derive(Clone)]
+pub struct Store {
+    db: Arc<Database>,
+}
+
+fn chunk_key(volume_uuid: &str, chunk_index: u32) -> Vec<u8> {
+    let mut k = Vec::with_capacity(volume_uuid.len() + 1 + 4);
+    k.extend_from_slice(volume_uuid.as_bytes());
+    k.push(b'|');
+    k.extend_from_slice(&chunk_index.to_be_bytes());
+    k
+}
+
+impl Store {
+    /// Open (and if needed, create) a store at `path`.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let db = Database::create(path.as_ref()).context("open redb database")?;
+        // Ensure tables exist.
+        let wtx = db.begin_write()?;
+        {
+            let _ = wtx.open_table(POOLS)?;
+            let _ = wtx.open_table(DISKS)?;
+            let _ = wtx.open_table(VOLUMES)?;
+            let _ = wtx.open_table(CHUNK_MAPS)?;
+            let _ = wtx.open_table(TASKS)?;
+        }
+        wtx.commit()?;
+        Ok(Self { db: Arc::new(db) })
+    }
+
+    // --- Pools -----------------------------------------------------------
+
+    pub fn put_pool(&self, pool: &Pool) -> Result<()> {
+        let bytes = postcard::to_allocvec(pool)?;
+        let wtx = self.db.begin_write()?;
+        {
+            let mut t = wtx.open_table(POOLS)?;
+            t.insert(pool.uuid.as_str(), bytes)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    pub fn get_pool(&self, uuid: &str) -> Result<Option<Pool>> {
+        let rtx = self.db.begin_read()?;
+        let t = rtx.open_table(POOLS)?;
+        match t.get(uuid)? {
+            Some(v) => Ok(Some(postcard::from_bytes(&v.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn list_pools(&self) -> Result<Vec<Pool>> {
+        let rtx = self.db.begin_read()?;
+        let t = rtx.open_table(POOLS)?;
+        let mut out = Vec::new();
+        for r in t.iter()? {
+            let (_, v) = r?;
+            out.push(postcard::from_bytes(&v.value())?);
+        }
+        Ok(out)
+    }
+
+    pub fn delete_pool(&self, uuid: &str) -> Result<()> {
+        let wtx = self.db.begin_write()?;
+        {
+            let mut t = wtx.open_table(POOLS)?;
+            t.remove(uuid)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    // --- Disks -----------------------------------------------------------
+
+    pub fn put_disk(&self, disk: &Disk) -> Result<()> {
+        let bytes = postcard::to_allocvec(disk)?;
+        let wtx = self.db.begin_write()?;
+        {
+            let mut t = wtx.open_table(DISKS)?;
+            t.insert(disk.uuid.as_str(), bytes)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    pub fn get_disk(&self, uuid: &str) -> Result<Option<Disk>> {
+        let rtx = self.db.begin_read()?;
+        let t = rtx.open_table(DISKS)?;
+        match t.get(uuid)? {
+            Some(v) => Ok(Some(postcard::from_bytes(&v.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn list_disks(&self) -> Result<Vec<Disk>> {
+        let rtx = self.db.begin_read()?;
+        let t = rtx.open_table(DISKS)?;
+        let mut out = Vec::new();
+        for r in t.iter()? {
+            let (_, v) = r?;
+            out.push(postcard::from_bytes(&v.value())?);
+        }
+        Ok(out)
+    }
+
+    pub fn list_disks_for_pool(&self, pool_uuid: &str) -> Result<Vec<Disk>> {
+        Ok(self
+            .list_disks()?
+            .into_iter()
+            .filter(|d| d.pool_uuid == pool_uuid)
+            .collect())
+    }
+
+    pub fn delete_disk(&self, uuid: &str) -> Result<()> {
+        let wtx = self.db.begin_write()?;
+        {
+            let mut t = wtx.open_table(DISKS)?;
+            t.remove(uuid)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    // --- Volumes ---------------------------------------------------------
+
+    pub fn put_volume(&self, vol: &Volume) -> Result<()> {
+        let bytes = postcard::to_allocvec(vol)?;
+        let wtx = self.db.begin_write()?;
+        {
+            let mut t = wtx.open_table(VOLUMES)?;
+            t.insert(vol.uuid.as_str(), bytes)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    pub fn get_volume(&self, uuid: &str) -> Result<Option<Volume>> {
+        let rtx = self.db.begin_read()?;
+        let t = rtx.open_table(VOLUMES)?;
+        match t.get(uuid)? {
+            Some(v) => Ok(Some(postcard::from_bytes(&v.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn list_volumes(&self) -> Result<Vec<Volume>> {
+        let rtx = self.db.begin_read()?;
+        let t = rtx.open_table(VOLUMES)?;
+        let mut out = Vec::new();
+        for r in t.iter()? {
+            let (_, v) = r?;
+            out.push(postcard::from_bytes(&v.value())?);
+        }
+        Ok(out)
+    }
+
+    pub fn delete_volume(&self, uuid: &str) -> Result<()> {
+        let wtx = self.db.begin_write()?;
+        {
+            {
+                let mut t = wtx.open_table(VOLUMES)?;
+                t.remove(uuid)?;
+            }
+            // Remove all chunk map entries for this volume.
+            let mut chunks = wtx.open_table(CHUNK_MAPS)?;
+            let prefix = uuid.as_bytes().to_vec();
+            let mut keys_to_remove = Vec::new();
+            for r in chunks.iter()? {
+                let (k, _) = r?;
+                let kbytes = k.value().to_vec();
+                if kbytes.len() > prefix.len()
+                    && kbytes[..prefix.len()] == prefix[..]
+                    && kbytes[prefix.len()] == b'|'
+                {
+                    keys_to_remove.push(kbytes);
+                }
+            }
+            for k in keys_to_remove {
+                chunks.remove(k.as_slice())?;
+            }
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    // --- Chunk maps ------------------------------------------------------
+
+    /// Replace the chunk map for `volume_uuid` with `placements`. Atomic: any
+    /// previous chunk map for that volume is wiped first.
+    pub fn put_chunk_map(&self, volume_uuid: &str, placements: &[ChunkPlacement]) -> Result<()> {
+        let wtx = self.db.begin_write()?;
+        {
+            let mut t = wtx.open_table(CHUNK_MAPS)?;
+            // Wipe existing entries for volume.
+            let prefix = volume_uuid.as_bytes().to_vec();
+            let mut to_remove = Vec::new();
+            for r in t.iter()? {
+                let (k, _) = r?;
+                let kb = k.value().to_vec();
+                if kb.len() > prefix.len()
+                    && kb[..prefix.len()] == prefix[..]
+                    && kb[prefix.len()] == b'|'
+                {
+                    to_remove.push(kb);
+                }
+            }
+            for k in to_remove {
+                t.remove(k.as_slice())?;
+            }
+            for p in placements {
+                let key = chunk_key(volume_uuid, p.index);
+                let bytes = postcard::to_allocvec(p)?;
+                t.insert(key.as_slice(), bytes)?;
+            }
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    pub fn get_chunk_map(&self, volume_uuid: &str) -> Result<ChunkMap> {
+        let rtx = self.db.begin_read()?;
+        let t = rtx.open_table(CHUNK_MAPS)?;
+        let mut chunks = Vec::new();
+        let prefix = volume_uuid.as_bytes().to_vec();
+        for r in t.iter()? {
+            let (k, v) = r?;
+            let kb = k.value().to_vec();
+            if kb.len() > prefix.len()
+                && kb[..prefix.len()] == prefix[..]
+                && kb[prefix.len()] == b'|'
+            {
+                let p: ChunkPlacement = postcard::from_bytes(&v.value())?;
+                chunks.push(p);
+            }
+        }
+        chunks.sort_by_key(|c| c.index);
+        Ok(ChunkMap {
+            volume_uuid: volume_uuid.to_string(),
+            chunks,
+        })
+    }
+
+    /// Update a single chunk placement (e.g. after a replication task acks).
+    pub fn put_chunk_placement(&self, volume_uuid: &str, placement: &ChunkPlacement) -> Result<()> {
+        let wtx = self.db.begin_write()?;
+        {
+            let mut t = wtx.open_table(CHUNK_MAPS)?;
+            let key = chunk_key(volume_uuid, placement.index);
+            let bytes = postcard::to_allocvec(placement)?;
+            t.insert(key.as_slice(), bytes)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    // --- Tasks -----------------------------------------------------------
+
+    pub fn put_task(&self, task: &Task) -> Result<()> {
+        let bytes = postcard::to_allocvec(task)?;
+        let wtx = self.db.begin_write()?;
+        {
+            let mut t = wtx.open_table(TASKS)?;
+            t.insert(task.id.as_str(), bytes)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    pub fn list_tasks(&self) -> Result<Vec<Task>> {
+        let rtx = self.db.begin_read()?;
+        let t = rtx.open_table(TASKS)?;
+        let mut out: Vec<Task> = Vec::new();
+        for r in t.iter()? {
+            let (_, v) = r?;
+            out.push(postcard::from_bytes(&v.value())?);
+        }
+        // Stable order by created_unix_secs then id.
+        out.sort_by(|a, b| {
+            a.created_unix_secs
+                .cmp(&b.created_unix_secs)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        Ok(out)
+    }
+
+    pub fn delete_task(&self, id: &str) -> Result<()> {
+        let wtx = self.db.begin_write()?;
+        {
+            let mut t = wtx.open_table(TASKS)?;
+            t.remove(id)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    pub fn task_exists_for(&self, predicate: impl Fn(&Task) -> bool) -> Result<bool> {
+        Ok(self.list_tasks()?.iter().any(predicate))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ProtectionSpec, TaskPayload};
+
+    fn tempstore() -> Store {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("store.redb");
+        // tempdir is dropped after function but Database keeps file open;
+        // leak the dir for the test's lifetime.
+        let leaked: &'static tempfile::TempDir = Box::leak(Box::new(dir));
+        let _ = leaked.path();
+        Store::open(path).unwrap()
+    }
+
+    #[test]
+    fn pools_roundtrip() {
+        let s = tempstore();
+        let p = Pool {
+            uuid: "p1".into(),
+            name: "pool1".into(),
+            replication_factor: 2,
+            tier: "fast".into(),
+            generation: 1,
+        };
+        s.put_pool(&p).unwrap();
+        assert_eq!(s.get_pool("p1").unwrap().unwrap(), p);
+        assert_eq!(s.list_pools().unwrap().len(), 1);
+        s.delete_pool("p1").unwrap();
+        assert!(s.get_pool("p1").unwrap().is_none());
+    }
+
+    #[test]
+    fn disks_roundtrip() {
+        let s = tempstore();
+        let d = Disk {
+            uuid: "d1".into(),
+            node: "node1".into(),
+            device_path: "/dev/nvme0n1".into(),
+            size_bytes: 1024,
+            pool_uuid: "p1".into(),
+            state: "ready".into(),
+            tier: "fast".into(),
+            present: true,
+            generation: 1,
+        };
+        s.put_disk(&d).unwrap();
+        assert_eq!(s.get_disk("d1").unwrap().unwrap(), d);
+        assert_eq!(s.list_disks_for_pool("p1").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn volumes_and_chunk_maps_atomic_delete() {
+        let s = tempstore();
+        let v = Volume {
+            uuid: "v1".into(),
+            name: "vol1".into(),
+            pool_uuid: "p1".into(),
+            size_bytes: 16 * 1024 * 1024,
+            protection: ProtectionSpec {
+                replication_factor: 2,
+            },
+            chunk_size_bytes: 4 * 1024 * 1024,
+            chunk_count: 4,
+            generation: 1,
+        };
+        s.put_volume(&v).unwrap();
+        let placements = (0u32..4)
+            .map(|i| ChunkPlacement {
+                index: i,
+                chunk_id: String::new(),
+                disk_uuids: vec![format!("d{i}-a"), format!("d{i}-b")],
+            })
+            .collect::<Vec<_>>();
+        s.put_chunk_map("v1", &placements).unwrap();
+        let cm = s.get_chunk_map("v1").unwrap();
+        assert_eq!(cm.chunks.len(), 4);
+        s.delete_volume("v1").unwrap();
+        assert_eq!(s.get_chunk_map("v1").unwrap().chunks.len(), 0);
+    }
+
+    #[test]
+    fn tasks_roundtrip_and_order() {
+        let s = tempstore();
+        let t1 = Task {
+            id: "a".into(),
+            created_unix_secs: 100,
+            payload: TaskPayload::ReleaseDisk {
+                disk_uuid: "d1".into(),
+            },
+        };
+        let t2 = Task {
+            id: "b".into(),
+            created_unix_secs: 50,
+            payload: TaskPayload::ReleaseDisk {
+                disk_uuid: "d2".into(),
+            },
+        };
+        s.put_task(&t1).unwrap();
+        s.put_task(&t2).unwrap();
+        let tasks = s.list_tasks().unwrap();
+        assert_eq!(tasks[0].id, "b");
+        assert_eq!(tasks[1].id, "a");
+        s.delete_task("a").unwrap();
+        assert_eq!(s.list_tasks().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn put_chunk_map_replaces_previous_entries() {
+        let s = tempstore();
+        let p1 = vec![
+            ChunkPlacement {
+                index: 0,
+                chunk_id: String::new(),
+                disk_uuids: vec!["a".into()],
+            },
+            ChunkPlacement {
+                index: 1,
+                chunk_id: String::new(),
+                disk_uuids: vec!["b".into()],
+            },
+        ];
+        s.put_chunk_map("v", &p1).unwrap();
+        let p2 = vec![ChunkPlacement {
+            index: 0,
+            chunk_id: String::new(),
+            disk_uuids: vec!["x".into()],
+        }];
+        s.put_chunk_map("v", &p2).unwrap();
+        let cm = s.get_chunk_map("v").unwrap();
+        assert_eq!(cm.chunks.len(), 1);
+        assert_eq!(cm.chunks[0].disk_uuids, vec!["x".to_string()]);
+    }
+}

--- a/storage/meta/src/topology.rs
+++ b/storage/meta/src/topology.rs
@@ -1,0 +1,64 @@
+//! Single-host topology used to feed CRUSH.
+//!
+//! Failure domain in this design is **the disk** (a single host has only one
+//! node). The topology is a flat list of `(disk_uuid, weight)` per pool.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiskCandidate {
+    pub disk_uuid: String,
+    pub weight: u64,
+}
+
+/// A flat list of disks eligible for placement within a single pool.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PoolTopology {
+    pub pool_uuid: String,
+    pub disks: Vec<DiskCandidate>,
+}
+
+impl PoolTopology {
+    pub fn new(pool_uuid: impl Into<String>) -> Self {
+        Self {
+            pool_uuid: pool_uuid.into(),
+            disks: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, disk_uuid: impl Into<String>, weight: u64) {
+        self.disks.push(DiskCandidate {
+            disk_uuid: disk_uuid.into(),
+            weight: weight.max(1),
+        });
+    }
+
+    pub fn len(&self) -> usize {
+        self.disks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.disks.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn topology_push_clamps_weight_to_one() {
+        let mut t = PoolTopology::new("p");
+        t.push("d", 0);
+        assert_eq!(t.disks[0].weight, 1);
+    }
+
+    #[test]
+    fn topology_len() {
+        let mut t = PoolTopology::new("p");
+        assert!(t.is_empty());
+        t.push("a", 1);
+        t.push("b", 1);
+        assert_eq!(t.len(), 2);
+    }
+}

--- a/storage/meta/src/types.rs
+++ b/storage/meta/src/types.rs
@@ -1,0 +1,240 @@
+//! Rust value types persisted in redb, plus conversions to/from the prost
+//! generated wire types.
+
+use serde::{Deserialize, Serialize};
+
+use crate::proto;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Pool {
+    pub uuid: String,
+    pub name: String,
+    pub replication_factor: u32,
+    pub tier: String,
+    pub generation: u64,
+}
+
+impl From<Pool> for proto::Pool {
+    fn from(p: Pool) -> Self {
+        Self {
+            uuid: p.uuid,
+            name: p.name,
+            replication_factor: p.replication_factor,
+            tier: p.tier,
+            generation: p.generation,
+        }
+    }
+}
+
+impl From<proto::Pool> for Pool {
+    fn from(p: proto::Pool) -> Self {
+        Self {
+            uuid: p.uuid,
+            name: p.name,
+            replication_factor: if p.replication_factor == 0 {
+                2
+            } else {
+                p.replication_factor
+            },
+            tier: p.tier,
+            generation: p.generation,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Disk {
+    pub uuid: String,
+    pub node: String,
+    pub device_path: String,
+    pub size_bytes: u64,
+    pub pool_uuid: String,
+    pub state: String,
+    pub tier: String,
+    pub present: bool,
+    pub generation: u64,
+}
+
+impl From<Disk> for proto::Disk {
+    fn from(d: Disk) -> Self {
+        Self {
+            uuid: d.uuid,
+            node: d.node,
+            device_path: d.device_path,
+            size_bytes: d.size_bytes,
+            pool_uuid: d.pool_uuid,
+            state: d.state,
+            tier: d.tier,
+            present: d.present,
+            generation: d.generation,
+        }
+    }
+}
+
+impl From<proto::Disk> for Disk {
+    fn from(d: proto::Disk) -> Self {
+        Self {
+            uuid: d.uuid,
+            node: d.node,
+            device_path: d.device_path,
+            size_bytes: d.size_bytes,
+            pool_uuid: d.pool_uuid,
+            state: d.state,
+            tier: d.tier,
+            present: d.present,
+            generation: d.generation,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProtectionSpec {
+    pub replication_factor: u32,
+}
+
+impl From<ProtectionSpec> for proto::ProtectionSpec {
+    fn from(p: ProtectionSpec) -> Self {
+        Self {
+            replication_factor: p.replication_factor,
+        }
+    }
+}
+
+impl From<proto::ProtectionSpec> for ProtectionSpec {
+    fn from(p: proto::ProtectionSpec) -> Self {
+        Self {
+            replication_factor: p.replication_factor,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Volume {
+    pub uuid: String,
+    pub name: String,
+    pub pool_uuid: String,
+    pub size_bytes: u64,
+    pub protection: ProtectionSpec,
+    pub chunk_size_bytes: u64,
+    pub chunk_count: u64,
+    pub generation: u64,
+}
+
+impl From<Volume> for proto::Volume {
+    fn from(v: Volume) -> Self {
+        Self {
+            uuid: v.uuid,
+            name: v.name,
+            pool_uuid: v.pool_uuid,
+            size_bytes: v.size_bytes,
+            protection: Some(v.protection.into()),
+            chunk_size_bytes: v.chunk_size_bytes,
+            chunk_count: v.chunk_count,
+            generation: v.generation,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ChunkPlacement {
+    pub index: u32,
+    pub chunk_id: String,
+    pub disk_uuids: Vec<String>,
+}
+
+impl From<ChunkPlacement> for proto::ChunkPlacement {
+    fn from(c: ChunkPlacement) -> Self {
+        Self {
+            index: c.index,
+            chunk_id: c.chunk_id,
+            disk_uuids: c.disk_uuids,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ChunkMap {
+    pub volume_uuid: String,
+    pub chunks: Vec<ChunkPlacement>,
+}
+
+impl From<ChunkMap> for proto::ChunkMap {
+    fn from(m: ChunkMap) -> Self {
+        Self {
+            volume_uuid: m.volume_uuid,
+            chunks: m.chunks.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tasks
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TaskPayload {
+    ClaimDisk {
+        disk_uuid: String,
+        pool_uuid: String,
+    },
+    ReleaseDisk {
+        disk_uuid: String,
+    },
+    ReplicateChunk {
+        volume_uuid: String,
+        chunk_index: u32,
+        source_disk_uuids: Vec<String>,
+        target_disk_uuids: Vec<String>,
+    },
+    // Future: TierMigrateChunk { ... }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Task {
+    pub id: String,
+    pub created_unix_secs: u64,
+    pub payload: TaskPayload,
+}
+
+impl Task {
+    pub fn to_proto(&self) -> proto::Task {
+        let (kind, payload) = match &self.payload {
+            TaskPayload::ClaimDisk {
+                disk_uuid,
+                pool_uuid,
+            } => (
+                proto::TaskKind::TaskClaimDisk,
+                Some(proto::task::Payload::ClaimDisk(proto::ClaimDiskTask {
+                    disk_uuid: disk_uuid.clone(),
+                    pool_uuid: pool_uuid.clone(),
+                })),
+            ),
+            TaskPayload::ReleaseDisk { disk_uuid } => (
+                proto::TaskKind::TaskReleaseDisk,
+                Some(proto::task::Payload::ReleaseDisk(proto::ReleaseDiskTask {
+                    disk_uuid: disk_uuid.clone(),
+                })),
+            ),
+            TaskPayload::ReplicateChunk {
+                volume_uuid,
+                chunk_index,
+                source_disk_uuids,
+                target_disk_uuids,
+            } => (
+                proto::TaskKind::TaskReplicateChunk,
+                Some(proto::task::Payload::ChunkOp(proto::ChunkOpTask {
+                    volume_uuid: volume_uuid.clone(),
+                    chunk_index: *chunk_index,
+                    source_disk_uuids: source_disk_uuids.clone(),
+                    target_disk_uuids: target_disk_uuids.clone(),
+                })),
+            ),
+        };
+        proto::Task {
+            id: self.id.clone(),
+            kind: kind as i32,
+            created_unix_secs: self.created_unix_secs,
+            payload,
+        }
+    }
+}

--- a/storage/meta/tests/api_subscriber.rs
+++ b/storage/meta/tests/api_subscriber.rs
@@ -1,0 +1,145 @@
+//! Hand-rolled fake `novanas-api` HTTP server. Drives `ApiSubscriber::tick`
+//! and asserts the resulting local store state.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use novanas_meta::api_client::{ApiSubscriber, ApiSubscriberConfig};
+use novanas_meta::store::Store;
+use novanas_meta::types::TaskPayload;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+#[derive(Default)]
+struct FakeApi {
+    pools: String,
+    disks: String,
+    volumes: String,
+}
+
+async fn run_fake_api(state: Arc<Mutex<FakeApi>>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let state = state.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 8192];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                if n == 0 {
+                    return;
+                }
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let body = {
+                    let s = state.lock().await;
+                    if req.contains("/api/v1/pools") {
+                        s.pools.clone()
+                    } else if req.contains("/api/v1/disks") {
+                        s.disks.clone()
+                    } else if req.contains("/api/v1/block-volumes") {
+                        s.volumes.clone()
+                    } else {
+                        "[]".to_string()
+                    }
+                };
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    port
+}
+
+fn temp_store() -> Store {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s.redb");
+    let leaked: &'static tempfile::TempDir = Box::leak(Box::new(dir));
+    let _ = leaked.path();
+    Store::open(path).unwrap()
+}
+
+#[tokio::test]
+async fn subscriber_reconciles_full_view() {
+    let state = Arc::new(Mutex::new(FakeApi::default()));
+    let port = run_fake_api(state.clone()).await;
+
+    {
+        let mut s = state.lock().await;
+        s.pools = r#"[{"uuid":"p1","name":"p1","replicationFactor":2,"tier":"fast"}]"#.into();
+        s.disks = r#"[
+            {"uuid":"d0","sizeBytes":10737418240,"poolUuid":"p1","state":"ready","tier":"fast","present":true,"devicePath":"/dev/x0"},
+            {"uuid":"d1","sizeBytes":10737418240,"poolUuid":"p1","state":"ready","tier":"fast","present":true,"devicePath":"/dev/x1"},
+            {"uuid":"d2","sizeBytes":10737418240,"poolUuid":"p1","state":"ready","tier":"fast","present":true,"devicePath":"/dev/x2"}
+        ]"#.into();
+        s.volumes = r#"[{"uuid":"v1","name":"vol1","poolUuid":"p1","sizeBytes":16777216,"protection":{"replicationFactor":2}}]"#.into();
+    }
+
+    let store = temp_store();
+    let cfg = ApiSubscriberConfig {
+        base_url: format!("http://127.0.0.1:{port}"),
+        poll_interval: Duration::from_secs(60),
+        node_name: "test".into(),
+    };
+    let sub = ApiSubscriber::new(cfg, store.clone()).unwrap();
+    sub.tick().await.unwrap();
+
+    assert_eq!(store.list_pools().unwrap().len(), 1);
+    assert_eq!(store.list_disks().unwrap().len(), 3);
+    assert_eq!(store.list_volumes().unwrap().len(), 1);
+
+    let cm = store.get_chunk_map("v1").unwrap();
+    assert_eq!(cm.chunks.len(), 4); // 16 MiB / 4 MiB
+    for c in &cm.chunks {
+        assert_eq!(c.disk_uuids.len(), 2);
+    }
+
+    // Three claim tasks should have been emitted (one per claimed disk).
+    let tasks = store.list_tasks().unwrap();
+    let claim_count = tasks
+        .iter()
+        .filter(|t| matches!(t.payload, TaskPayload::ClaimDisk { .. }))
+        .count();
+    assert_eq!(claim_count, 3);
+
+    // A second tick must be idempotent: no new claim tasks, no duplicate
+    // volume.
+    sub.tick().await.unwrap();
+    assert_eq!(store.list_volumes().unwrap().len(), 1);
+    let tasks2 = store.list_tasks().unwrap();
+    let claim_count2 = tasks2
+        .iter()
+        .filter(|t| matches!(t.payload, TaskPayload::ClaimDisk { .. }))
+        .count();
+    assert_eq!(claim_count2, 3);
+}
+
+#[tokio::test]
+async fn subscriber_skips_volume_when_pool_unknown() {
+    let state = Arc::new(Mutex::new(FakeApi::default()));
+    let port = run_fake_api(state.clone()).await;
+    {
+        let mut s = state.lock().await;
+        s.pools = "[]".into();
+        s.disks = "[]".into();
+        s.volumes = r#"[{"uuid":"v","poolUuid":"missing","sizeBytes":4194304}]"#.into();
+    }
+    let store = temp_store();
+    let sub = ApiSubscriber::new(
+        ApiSubscriberConfig {
+            base_url: format!("http://127.0.0.1:{port}"),
+            poll_interval: Duration::from_secs(60),
+            node_name: "test".into(),
+        },
+        store.clone(),
+    )
+    .unwrap();
+    sub.tick().await.unwrap();
+    assert_eq!(store.list_volumes().unwrap().len(), 0);
+}

--- a/storage/meta/tests/grpc_smoke.rs
+++ b/storage/meta/tests/grpc_smoke.rs
@@ -1,0 +1,292 @@
+//! End-to-end gRPC smoke test: spin up a real `MetaServer` on a temp UDS,
+//! call every RPC at least once via a tonic client.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use novanas_meta::proto::meta_service_client::MetaServiceClient;
+use novanas_meta::proto::*;
+use novanas_meta::server::MetaServer;
+use novanas_meta::store::Store;
+use tokio::net::{UnixListener, UnixStream};
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::transport::{Endpoint, Server, Uri};
+use tower::service_fn;
+
+async fn spawn_server() -> (MetaServiceClient<tonic::transport::Channel>, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("meta.sock");
+    let store_path = dir.path().join("meta.redb");
+    let store = Store::open(&store_path).unwrap();
+    let svc = MetaServer::new(store).into_service();
+
+    // Leak temp dir for test lifetime.
+    let leaked: &'static tempfile::TempDir = Box::leak(Box::new(dir));
+    let _ = leaked.path();
+
+    let listener = UnixListener::bind(&socket).unwrap();
+    let stream = UnixListenerStream::new(listener);
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(stream)
+            .await
+            .unwrap();
+    });
+    // Give server a moment to start accepting.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let socket_for_connect = socket.clone();
+    let channel = Endpoint::try_from("http://[::]:50051")
+        .unwrap()
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let p = socket_for_connect.clone();
+            async move {
+                let s = UnixStream::connect(p).await?;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(s))
+            }
+        }))
+        .await
+        .unwrap();
+    (MetaServiceClient::new(channel), socket)
+}
+
+#[tokio::test]
+async fn end_to_end_rpcs() {
+    let (mut client, _sock) = spawn_server().await;
+
+    // Heartbeat
+    let hb = client
+        .heartbeat(HeartbeatRequest {
+            client_id: "test".into(),
+        })
+        .await
+        .unwrap();
+    assert!(hb.into_inner().server_unix_secs > 0);
+
+    // PutPool / GetPool / ListPools
+    client
+        .put_pool(PutPoolRequest {
+            pool: Some(Pool {
+                uuid: "p1".into(),
+                name: "pool1".into(),
+                replication_factor: 2,
+                tier: "fast".into(),
+                generation: 0,
+            }),
+        })
+        .await
+        .unwrap();
+    let got = client
+        .get_pool(GetPoolRequest { uuid: "p1".into() })
+        .await
+        .unwrap()
+        .into_inner()
+        .pool
+        .unwrap();
+    assert_eq!(got.uuid, "p1");
+    let pools = client
+        .list_pools(ListPoolsRequest {})
+        .await
+        .unwrap()
+        .into_inner()
+        .pools;
+    assert_eq!(pools.len(), 1);
+
+    // PutDisk x3
+    for i in 0..3 {
+        client
+            .put_disk(PutDiskRequest {
+                disk: Some(Disk {
+                    uuid: format!("d{i}"),
+                    node: "local".into(),
+                    device_path: format!("/dev/x{i}"),
+                    size_bytes: 10 * 1024 * 1024 * 1024,
+                    pool_uuid: "p1".into(),
+                    state: "ready".into(),
+                    tier: "fast".into(),
+                    present: true,
+                    generation: 0,
+                }),
+            })
+            .await
+            .unwrap();
+    }
+    let disks = client
+        .list_disks(ListDisksRequest {
+            pool_uuid: "p1".into(),
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .disks;
+    assert_eq!(disks.len(), 3);
+    let _ = client
+        .get_disk(GetDiskRequest { uuid: "d0".into() })
+        .await
+        .unwrap();
+
+    // ClaimDisk + ReleaseDisk
+    client
+        .claim_disk(ClaimDiskRequest {
+            disk_uuid: "d0".into(),
+            pool_uuid: "p1".into(),
+        })
+        .await
+        .unwrap();
+    client
+        .release_disk(ReleaseDiskRequest {
+            disk_uuid: "d0".into(),
+        })
+        .await
+        .unwrap();
+    // Re-claim so volume creation has 3 eligible disks.
+    client
+        .put_disk(PutDiskRequest {
+            disk: Some(Disk {
+                uuid: "d0".into(),
+                node: "local".into(),
+                device_path: "/dev/x0".into(),
+                size_bytes: 10 * 1024 * 1024 * 1024,
+                pool_uuid: "p1".into(),
+                state: "ready".into(),
+                tier: "fast".into(),
+                present: true,
+                generation: 0,
+            }),
+        })
+        .await
+        .unwrap();
+
+    // CreateVolume
+    let cv = client
+        .create_volume(CreateVolumeRequest {
+            uuid: "v1".into(),
+            name: "vol".into(),
+            pool_uuid: "p1".into(),
+            size_bytes: 16 * 1024 * 1024,
+            protection: Some(ProtectionSpec {
+                replication_factor: 2,
+            }),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(cv.volume.as_ref().unwrap().chunk_count, 4);
+    assert_eq!(cv.chunk_map.as_ref().unwrap().chunks.len(), 4);
+
+    let cm = client
+        .get_chunk_map(GetChunkMapRequest {
+            volume_uuid: "v1".into(),
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .chunk_map
+        .unwrap();
+    assert_eq!(cm.chunks.len(), 4);
+    for c in &cm.chunks {
+        assert_eq!(c.disk_uuids.len(), 2);
+    }
+
+    // ListVolumes / GetVolume
+    let vols = client
+        .list_volumes(ListVolumesRequest {
+            pool_uuid: "p1".into(),
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .volumes;
+    assert_eq!(vols.len(), 1);
+    let _ = client
+        .get_volume(GetVolumeRequest { uuid: "v1".into() })
+        .await
+        .unwrap();
+
+    // PollTasks (we should have at least the claim+release tasks from above).
+    let tasks = client
+        .poll_tasks(PollTasksRequest { max: 100 })
+        .await
+        .unwrap()
+        .into_inner()
+        .tasks;
+    assert!(!tasks.is_empty());
+    let first_id = tasks[0].id.clone();
+    client
+        .ack_task(AckTaskRequest {
+            task_id: first_id.clone(),
+            success: true,
+            error: String::new(),
+        })
+        .await
+        .unwrap();
+    let after = client
+        .poll_tasks(PollTasksRequest { max: 100 })
+        .await
+        .unwrap()
+        .into_inner()
+        .tasks;
+    assert!(after.iter().all(|t| t.id != first_id));
+
+    // DeleteVolume / DeleteDisk / DeletePool
+    client
+        .delete_volume(DeleteVolumeRequest { uuid: "v1".into() })
+        .await
+        .unwrap();
+    client
+        .delete_disk(DeleteDiskRequest { uuid: "d0".into() })
+        .await
+        .unwrap();
+    client
+        .delete_pool(DeletePoolRequest { uuid: "p1".into() })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn create_volume_errors_when_too_few_disks() {
+    let (mut client, _) = spawn_server().await;
+    client
+        .put_pool(PutPoolRequest {
+            pool: Some(Pool {
+                uuid: "p".into(),
+                name: "p".into(),
+                replication_factor: 3,
+                tier: "fast".into(),
+                generation: 0,
+            }),
+        })
+        .await
+        .unwrap();
+    // Only one disk, replication 3 -> error.
+    client
+        .put_disk(PutDiskRequest {
+            disk: Some(Disk {
+                uuid: "only".into(),
+                node: "local".into(),
+                device_path: "/dev/x".into(),
+                size_bytes: 10 * 1024 * 1024 * 1024,
+                pool_uuid: "p".into(),
+                state: "ready".into(),
+                tier: "fast".into(),
+                present: true,
+                generation: 0,
+            }),
+        })
+        .await
+        .unwrap();
+    let err = client
+        .create_volume(CreateVolumeRequest {
+            uuid: "v".into(),
+            name: "v".into(),
+            pool_uuid: "p".into(),
+            size_bytes: 4 * 1024 * 1024,
+            protection: Some(ProtectionSpec {
+                replication_factor: 3,
+            }),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+}

--- a/storage/meta/tests/store_invariants.rs
+++ b/storage/meta/tests/store_invariants.rs
@@ -1,0 +1,135 @@
+//! End-to-end store invariants: drive the redb store through a realistic
+//! pool-create → claim-disks → create-volume → policy-tick → ack-tasks
+//! sequence, asserting state transitions at each step.
+
+use novanas_meta::policy::{PolicyChecker, PolicyConfig};
+use novanas_meta::store::Store;
+use novanas_meta::types::{ChunkPlacement, Disk, Pool, ProtectionSpec, Task, TaskPayload, Volume};
+
+fn temp_store() -> Store {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("s.redb");
+    let leaked: &'static tempfile::TempDir = Box::leak(Box::new(dir));
+    let _ = leaked.path();
+    Store::open(path).unwrap()
+}
+
+#[test]
+fn full_lifecycle() {
+    let s = temp_store();
+
+    // 1. Pool created.
+    let pool = Pool {
+        uuid: "p".into(),
+        name: "p".into(),
+        replication_factor: 2,
+        tier: "fast".into(),
+        generation: 1,
+    };
+    s.put_pool(&pool).unwrap();
+    assert_eq!(s.list_pools().unwrap().len(), 1);
+
+    // 2. Three disks claimed.
+    for i in 0..3 {
+        s.put_disk(&Disk {
+            uuid: format!("d{i}"),
+            node: "local".into(),
+            device_path: format!("/dev/x{i}"),
+            size_bytes: 10 * 1024 * 1024 * 1024,
+            pool_uuid: "p".into(),
+            state: "ready".into(),
+            tier: "fast".into(),
+            present: true,
+            generation: 1,
+        })
+        .unwrap();
+    }
+    assert_eq!(s.list_disks_for_pool("p").unwrap().len(), 3);
+
+    // 3. Volume + chunk map populated (4 chunks, replication 2).
+    let v = Volume {
+        uuid: "v".into(),
+        name: "v".into(),
+        pool_uuid: "p".into(),
+        size_bytes: 16 * 1024 * 1024,
+        protection: ProtectionSpec {
+            replication_factor: 2,
+        },
+        chunk_size_bytes: 4 * 1024 * 1024,
+        chunk_count: 4,
+        generation: 1,
+    };
+    s.put_volume(&v).unwrap();
+    let placements: Vec<_> = (0u32..4)
+        .map(|i| ChunkPlacement {
+            index: i,
+            chunk_id: String::new(),
+            // Place each chunk on d0 + d1 (compliant).
+            disk_uuids: vec!["d0".into(), "d1".into()],
+        })
+        .collect();
+    s.put_chunk_map("v", &placements).unwrap();
+    let cm = s.get_chunk_map("v").unwrap();
+    assert_eq!(cm.chunks.len(), 4);
+
+    // 4. Policy tick — fully compliant — emits nothing.
+    let p = PolicyChecker::new(PolicyConfig::default(), s.clone());
+    p.tick().unwrap();
+    assert_eq!(s.list_tasks().unwrap().len(), 0);
+
+    // 5. Mark d1 absent → under-replicated.
+    let mut d1 = s.get_disk("d1").unwrap().unwrap();
+    d1.present = false;
+    s.put_disk(&d1).unwrap();
+    p.tick().unwrap();
+    let tasks = s.list_tasks().unwrap();
+    assert_eq!(tasks.len(), 4, "expected one ReplicateChunk task per chunk");
+    for t in &tasks {
+        match &t.payload {
+            TaskPayload::ReplicateChunk {
+                volume_uuid,
+                target_disk_uuids,
+                ..
+            } => {
+                assert_eq!(volume_uuid, "v");
+                assert_eq!(target_disk_uuids.len(), 2);
+            }
+            _ => panic!("unexpected task payload"),
+        }
+    }
+
+    // 6. Idempotent: a second tick does NOT double-emit.
+    p.tick().unwrap();
+    assert_eq!(s.list_tasks().unwrap().len(), 4);
+
+    // 7. Ack all tasks → tasks gone.
+    let ids: Vec<String> = tasks.iter().map(|t| t.id.clone()).collect();
+    for id in ids {
+        s.delete_task(&id).unwrap();
+    }
+    assert_eq!(s.list_tasks().unwrap().len(), 0);
+
+    // 8. Volume deletion clears chunk map atomically.
+    s.delete_volume("v").unwrap();
+    assert_eq!(s.get_chunk_map("v").unwrap().chunks.len(), 0);
+    assert!(s.get_volume("v").unwrap().is_none());
+}
+
+#[test]
+fn task_ordering_is_stable() {
+    let s = temp_store();
+    for (i, ts) in [(0u64, 100), (1, 50), (2, 200)].iter().enumerate() {
+        s.put_task(&Task {
+            id: format!("t{i}"),
+            created_unix_secs: ts.1,
+            payload: TaskPayload::ReleaseDisk {
+                disk_uuid: format!("d{i}"),
+            },
+        })
+        .unwrap();
+        let _ = ts.0;
+    }
+    let tasks = s.list_tasks().unwrap();
+    let times: Vec<u64> = tasks.iter().map(|t| t.created_unix_secs).collect();
+    assert_eq!(times, vec![50, 100, 200]);
+}


### PR DESCRIPTION
## Summary

Builds the **complete** `novanas-meta` daemon in Rust per [`docs/16-data-meta-frontend.md`](docs/16-data-meta-frontend.md). Replaces #75, which was opened on the wrong base (main, missing the strip + proto commits) and reinvented `meta.proto` rather than using the locked one.

This branch picks up that PR's working crate verbatim (3.3K LOC, 26 tests passing), rebases onto `chore/strip-backend-assignment`, and adopts its wrapper-style proto as the canonical contract. The wrapper-vs-direct-types difference is purely stylistic — RPC names, arity, and semantics are identical to the original draft. Frontend + data daemons (other parallel PRs) will consume the proto in this branch.

## What ships

- `storage/meta/` — Rust crate (workspace member). Modules: `main`, `lib`, `types`, `topology`, `crush`, `store`, `server`, `api_client`, `policy`.
- `storage/api/proto/meta/meta.proto` — wrapper-style messages, `MetaService` with 18 RPCs.
- `storage/.gitignore` — drop the Go-era `/meta` binary ignore so the new Rust crate is tracked.
- `Cargo.toml` workspace members += `storage/meta`.

## Daemon responsibilities

- **redb-backed store** for pools, disks, volumes, chunk maps, tasks. Atomic transactions for cross-table updates.
- **CRUSH placement** (straw2) with single-host failure-domain = disk; weights by size.
- **HTTP poller** subscribing to `novanas-api` for `Pool` / `Disk` / `BlockVolume` lifecycle. On `Disk.spec.pool` change, enqueues a `ClaimDiskTask`. On `BlockVolume` create, runs CRUSH and persists the chunk map.
- **Policy checker** (timer-driven, default 30s): walks every volume's chunk map, compares to its protection spec, enqueues `REPLICATE_CHUNK` tasks for under-replicated chunks. The tier-migration branch is a documented future hook (not a TODO).
- **gRPC server** on a Unix socket (default `/var/run/novanas/meta.sock`); optional `--listen-tcp` for tests. All 18 RPCs implemented end-to-end.

## Test plan

- [x] `cargo build -p novanas-meta --release` clean
- [x] `cargo test -p novanas-meta` — **26/26** (20 unit + 6 integration)
- [x] `cargo clippy -p novanas-meta --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI green on the PR

## Notes for downstream parallel PRs

- `storage/frontend/` (PR pending) and `storage/dataplane/` reshape (PR pending) both consume this proto. The wrapper-style `XxxRequest`/`XxxResponse` messages are stable from this point — frontend+data should generate Rust types from `storage/api/proto/meta/meta.proto` as it lands here.
- The proto package is `novanas.meta.v1`. Future changes are additive (new RPCs/messages) until v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)