### PR TITLE
fix(frontend): resolve SPDK-linked compile errors in env port (partial)

### DIFF
--- a/storage/frontend/build.rs
+++ b/storage/frontend/build.rs
@@ -110,6 +110,7 @@ fn main() {
             .allowlist_function("spdk_rpc.*")
             .allowlist_function("spdk_log.*")
             .allowlist_function("spdk_thread.*")
+            .allowlist_function("spdk_get_thread")
             .allowlist_function("spdk_dma_.*")
             .allowlist_function("spdk_io_device_register")
             .allowlist_function("spdk_io_device_unregister")

--- a/storage/frontend/src/spdk/reactor_dispatch.rs
+++ b/storage/frontend/src/spdk/reactor_dispatch.rs
@@ -321,9 +321,6 @@ pub fn query_bdev(name: &str) -> Result<(u64, u32)> {
     })
 }
 
-// Re-export the cached-bdev helpers for the volume_bdev module.
-pub(crate) use ffi as spdk_ffi;
-
 // Suppress dead-code warnings on the AsyncCompletion bridge that's shipped for
 // future I/O integration but not yet consumed.
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary

Three of the five `cargo build --features spdk-sys` errors that surfaced on the dev box rebuild of `novanas-frontend`:

- **E0365** \`ffi\` is private, and cannot be re-exported — drop the dead \`pub(crate) use ffi as spdk_ffi;\` re-export in [storage/frontend/src/spdk/reactor_dispatch.rs](storage/frontend/src/spdk/reactor_dispatch.rs). Nothing in the crate uses \`spdk_ffi\`; verified with \`grep -rn 'spdk_ffi'\`.
- **E0425 ×3** cannot find function \`spdk_get_thread\` in module \`ffi\` — the bindgen allowlist used \`spdk_thread.*\` which doesn't match \`spdk_get_thread\` (no \`_thread_\` infix). Add an explicit \`.allowlist_function("spdk_get_thread")\` in [storage/frontend/build.rs](storage/frontend/build.rs), matching dataplane's working build.rs.

The fifth error (**E0308** mismatched types) was not captured with file:line in the previous fix agent's log before the watchdog killed it. Will follow up once the next docker build surfaces the exact location.

## Test plan
- [ ] On the dev box, rebuild `novanas-frontend:dev` from this branch
- [ ] First three errors gone; capture the E0308 location
- [ ] Address E0308 in a follow-up commit on this branch
- [ ] Run frontend container against meta + data + 3 claimed disks; confirm NVMe-oF subsystem advertises smoke volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)